### PR TITLE
Fix MSAA sample count mismatch and static previews

### DIFF
--- a/patch.cjs
+++ b/patch.cjs
@@ -1,151 +1,18 @@
 const fs = require('fs');
-const path = require('path');
 
-const filePath = path.join(__dirname, 'src', 'engine', 'WebGPURenderer.ts');
-let content = fs.readFileSync(filePath, 'utf8');
+let code = fs.readFileSync('src/engine/WebGPURenderer.ts', 'utf8');
 
-// 1. Add msaaTexture property
-content = content.replace(
-  '  private texH = 0;',
-  '  private texH = 0;\n  private msaaTexture: GPUTexture | null = null;'
-);
+// 1. Fix sampleCount for layerTextures
+code = code.replace(/sampleCount: this\.sampleCount,(\s+\]\)\);)/, 'sampleCount: 1,$1');
 
-// 2. Update ensureLayerTextures
-const ensureTarget = `  private ensureLayerTextures(w: number, h: number): void {
-    if (this.texW === w && this.texH === h && this.layerTextures.length === 3) return;
-    for (const t of this.layerTextures) t.destroy();
-    this.layerTextures = [0, 1, 2].map(() => this.device.createTexture({
-      size : [w, h, 1],
-      format: this.format,
-      usage : GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
-    }));
-    this.texW = w;
-    this.texH = h;
-  }`;
-
-const ensureReplacement = `  private ensureLayerTextures(w: number, h: number): void {
-    if (this.texW === w && this.texH === h && this.layerTextures.length === 3) return;
-
-    for (const t of this.layerTextures) t.destroy();
-    if (this.msaaTexture) this.msaaTexture.destroy();
-
-    this.layerTextures = [0, 1, 2].map(() => this.device.createTexture({
-      size : [w, h, 1],
-      format: this.format,
-      usage : GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
-    }));
-
-    if (this.sampleCount > 1) {
-      this.msaaTexture = this.device.createTexture({
-        size: [w, h, 1],
-        format: this.format,
-        sampleCount: this.sampleCount,
-        usage: GPUTextureUsage.RENDER_ATTACHMENT,
-      });
-    } else {
-      this.msaaTexture = null;
-    }
-
-    this.texW = w;
-    this.texH = h;
-  }`;
-
-content = content.replace(ensureTarget, ensureReplacement);
-
-// 3. Update setAntialiasing
-const aaTarget = `  setAntialiasing(enabled: boolean): void {
-    const newSampleCount = enabled ? 4 : 1;
-    if (newSampleCount === this.sampleCount) return;
-    this.sampleCount = newSampleCount;
-    // Recreate pipelines with new sample count
-    this.layerPipelines = [];
-    const fragSources = [fragmentShaderRedOrange, fragmentShaderVioletBlue, fragmentShaderGreenYellow];
-    for (const src of fragSources) this.layerPipelines.push(this.createLayerPipeline(src));
-    this.compositorPipeline = this.createCompositorPipeline();
-  }`;
-
-const aaReplacement = `  setAntialiasing(enabled: boolean): void {
-    const newSampleCount = enabled ? 4 : 1;
-    if (newSampleCount === this.sampleCount) return;
-    this.sampleCount = newSampleCount;
-
-    // Force recreation of layer and MSAA textures on next render
-    this.texW = 0;
-
-    // Recreate pipelines with new sample count
-    this.layerPipelines = [];
-    const fragSources = [fragmentShaderRedOrange, fragmentShaderVioletBlue, fragmentShaderGreenYellow];
-    for (const src of fragSources) this.layerPipelines.push(this.createLayerPipeline(src));
-    this.compositorPipeline = this.createCompositorPipeline();
-  }`;
-
-content = content.replace(aaTarget, aaReplacement);
-
-// 4. Update beginRenderPass (layer passes)
-const passTarget = `      const pass = enc.beginRenderPass({
-        colorAttachments: [{
-          view      : this.layerTextures[i].createView(),
-          loadOp    : 'clear',
-          storeOp   : 'store',
-          clearValue: { r: 0, g: 0, b: 0, a: 0 },
-        }],
-      });`;
-
-const passReplacement = `      const pass = enc.beginRenderPass({
-        colorAttachments: [{
-          view      : this.sampleCount > 1 && this.msaaTexture ? this.msaaTexture.createView() : this.layerTextures[i].createView(),
-          resolveTarget: this.sampleCount > 1 ? this.layerTextures[i].createView() : undefined,
-          loadOp    : 'clear',
-          storeOp   : this.sampleCount > 1 ? 'discard' : 'store',
-          clearValue: { r: 0, g: 0, b: 0, a: 0 },
-        }],
-      });`;
-
-content = content.replace(passTarget, passReplacement);
-
-// 5. Update beginRenderPass (finalPass)
-const finalPassTarget = `    const finalPass = enc.beginRenderPass({
+// 2. Fix the final compositor pass (it doesn't need MSAA resolver)
+code = code.replace(
+  /const finalPass = enc\.beginRenderPass\(\{\s+colorAttachments: \[\{\s+view\s*: this\.sampleCount > 1 && this\.msaaTexture \? this\.msaaTexture\.createView\(\) : canvasTex\.createView\(\),\s+resolveTarget: this\.sampleCount > 1 \? canvasTex\.createView\(\) : undefined,\s+loadOp\s*: 'clear',\s+storeOp\s*: this\.sampleCount > 1 \? 'discard' : 'store',/g,
+  `const finalPass = enc.beginRenderPass({
       colorAttachments: [{
         view      : canvasTex.createView(),
         loadOp    : 'clear',
-        storeOp   : 'store',
-        clearValue: { r: 0, g: 0, b: 0, a: 1 },
-      }],
-    });`;
+        storeOp   : 'store',`
+);
 
-const finalPassReplacement = `    const finalPass = enc.beginRenderPass({
-      colorAttachments: [{
-        view      : this.sampleCount > 1 && this.msaaTexture ? this.msaaTexture.createView() : canvasTex.createView(),
-        resolveTarget: this.sampleCount > 1 ? canvasTex.createView() : undefined,
-        loadOp    : 'clear',
-        storeOp   : this.sampleCount > 1 ? 'discard' : 'store',
-        clearValue: { r: 0, g: 0, b: 0, a: 1 },
-      }],
-    });`;
-
-content = content.replace(finalPassTarget, finalPassReplacement);
-
-// 6. Update destroy
-const destroyTarget = `  destroy(): void {
-    for (const lp of this.layerPipelines) {
-      lp.rotationBuffer.destroy();
-      lp.fragUniformBuffer.destroy();
-    }
-    for (const t of this.layerTextures) t.destroy();
-    this.compositorUniformBuf.destroy();
-  }`;
-
-const destroyReplacement = `  destroy(): void {
-    for (const lp of this.layerPipelines) {
-      lp.rotationBuffer.destroy();
-      lp.fragUniformBuffer.destroy();
-    }
-    for (const t of this.layerTextures) t.destroy();
-    if (this.msaaTexture) this.msaaTexture.destroy();
-    this.compositorUniformBuf.destroy();
-  }`;
-
-content = content.replace(destroyTarget, destroyReplacement);
-
-fs.writeFileSync(filePath, content, 'utf8');
-console.log('Patched WebGPURenderer.ts successfully');
+fs.writeFileSync('src/engine/WebGPURenderer.ts', code);

--- a/patch2.cjs
+++ b/patch2.cjs
@@ -1,0 +1,20 @@
+const fs = require('fs');
+
+let code = fs.readFileSync('src/engine/WebGPURenderer.ts', 'utf8');
+
+code = code.replace(
+`    this.layerTextures = [0, 1, 2].map(() => this.device.createTexture({
+      size : [w, h, 1],
+      format: this.format,
+      usage : GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+      sampleCount: this.sampleCount,
+    }));`,
+`    this.layerTextures = [0, 1, 2].map(() => this.device.createTexture({
+      size : [w, h, 1],
+      format: this.format,
+      usage : GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+      sampleCount: 1, // Intermediate resolved textures should always be 1x
+    }));`
+);
+
+fs.writeFileSync('src/engine/WebGPURenderer.ts', code);

--- a/patch3.cjs
+++ b/patch3.cjs
@@ -1,0 +1,52 @@
+const fs = require('fs');
+let code = fs.readFileSync('src/App.tsx', 'utf8');
+
+// We need to add a ref `hasUpdatedPreviewsForImage = useRef(false)`
+code = code.replace(
+  /const previewTracerRef = useRef<HTMLCanvasElement>\(null\);/,
+  `const previewTracerRef = useRef<HTMLCanvasElement>(null);
+  const hasUpdatedPreviewsForImage = useRef(false);`
+);
+
+// We need to set it to false when the image changes
+code = code.replace(
+  /setCurrentImageIndex\(\(prev\) => \(prev \+ 1\) % imageList\.length\);/g,
+  `setCurrentImageIndex((prev) => {
+        hasUpdatedPreviewsForImage.current = false;
+        return (prev + 1) % imageList.length;
+      });`
+);
+
+code = code.replace(
+  /onClick=\{\(\) => setCurrentImageIndex\(idx\)\}/g,
+  `onClick={() => { hasUpdatedPreviewsForImage.current = false; setCurrentImageIndex(idx); }}`
+);
+
+// We need to wrap the preview updating block in a condition
+code = code.replace(
+  /\/\/ Update preview: copy main canvas to separated preview\s+const previewSep = previewSeparatedRef\.current;[\s\S]+?\/\/ Update preview: copy main canvas to tracer preview \(it's the same as separated, just labeled differently\)\s+const previewTracer = previewTracerRef\.current;\s+if \(previewTracer && canvasRef\.current\) \{\s+const ctx = previewTracer\.getContext\('2d'\);\s+if \(ctx\) \{\s+ctx\.drawImage\(canvasRef\.current, 0, 0, previewTracer\.width, previewTracer\.height\);\s+\}\s+\}/,
+  `// Update preview only on the first frame of a new image
+        if (!hasUpdatedPreviewsForImage.current) {
+          // Update preview: copy main canvas to separated preview
+          const previewSep = previewSeparatedRef.current;
+          if (previewSep && canvasRef.current) {
+            const ctx = previewSep.getContext('2d');
+            if (ctx) {
+              ctx.drawImage(canvasRef.current, 0, 0, previewSep.width, previewSep.height);
+            }
+          }
+
+          // Update preview: copy main canvas to tracer preview
+          const previewTracer = previewTracerRef.current;
+          if (previewTracer && canvasRef.current) {
+            const ctx = previewTracer.getContext('2d');
+            if (ctx) {
+              ctx.drawImage(canvasRef.current, 0, 0, previewTracer.width, previewTracer.height);
+            }
+          }
+
+          hasUpdatedPreviewsForImage.current = true;
+        }`
+);
+
+fs.writeFileSync('src/App.tsx', code);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ export default function App() {
   const previewOriginalRef = useRef<HTMLCanvasElement>(null);
   const previewSeparatedRef = useRef<HTMLCanvasElement>(null);
   const previewTracerRef = useRef<HTMLCanvasElement>(null);
+  const hasUpdatedPreviewsForImage = useRef(false);
 
   // Resize canvas: always square, max 95% of viewport height
   useEffect(() => {
@@ -172,7 +173,10 @@ export default function App() {
     if (!isAutoPlayActive || imageList.length === 0) return;
 
     const interval = setInterval(() => {
-      setCurrentImageIndex((prev) => (prev + 1) % imageList.length);
+      setCurrentImageIndex((prev) => {
+        hasUpdatedPreviewsForImage.current = false;
+        return (prev + 1) % imageList.length;
+      });
     }, imageChangeInterval * 1000);
 
     return () => clearInterval(interval);
@@ -213,22 +217,27 @@ export default function App() {
 
         rendererRef.current?.render(state);
 
-        // Update preview: copy main canvas to separated preview
-        const previewSep = previewSeparatedRef.current;
-        if (previewSep && canvasRef.current) {
-          const ctx = previewSep.getContext('2d');
-          if (ctx) {
-            ctx.drawImage(canvasRef.current, 0, 0, previewSep.width, previewSep.height);
+        // Update preview only on the first frame of a new image
+        if (!hasUpdatedPreviewsForImage.current) {
+          // Update preview: copy main canvas to separated preview
+          const previewSep = previewSeparatedRef.current;
+          if (previewSep && canvasRef.current) {
+            const ctx = previewSep.getContext('2d');
+            if (ctx) {
+              ctx.drawImage(canvasRef.current, 0, 0, previewSep.width, previewSep.height);
+            }
           }
-        }
 
-        // Update preview: copy main canvas to tracer preview (it's the same as separated, just labeled differently)
-        const previewTracer = previewTracerRef.current;
-        if (previewTracer && canvasRef.current) {
-          const ctx = previewTracer.getContext('2d');
-          if (ctx) {
-            ctx.drawImage(canvasRef.current, 0, 0, previewTracer.width, previewTracer.height);
+          // Update preview: copy main canvas to tracer preview
+          const previewTracer = previewTracerRef.current;
+          if (previewTracer && canvasRef.current) {
+            const ctx = previewTracer.getContext('2d');
+            if (ctx) {
+              ctx.drawImage(canvasRef.current, 0, 0, previewTracer.width, previewTracer.height);
+            }
           }
+
+          hasUpdatedPreviewsForImage.current = true;
         }
       }
 
@@ -328,7 +337,7 @@ export default function App() {
           {imageList.map((_, idx) => (
             <button
               key={idx}
-              onClick={() => setCurrentImageIndex(idx)}
+              onClick={() => { hasUpdatedPreviewsForImage.current = false; setCurrentImageIndex(idx); }}
               className={`w-2.5 h-2.5 rounded-full transition-colors ${
                 idx === currentImageIndex ? 'bg-white' : 'bg-white/30 hover:bg-white/60'
               }`}

--- a/src/engine/WebGPURenderer.ts
+++ b/src/engine/WebGPURenderer.ts
@@ -174,7 +174,7 @@ export class WebGPURenderer {
       size : [w, h, 1],
       format: this.format,
       usage : GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
-      sampleCount: this.sampleCount,
+      sampleCount: 1, // Intermediate resolved textures should always be 1x
     }));
 
     if (this.sampleCount > 1) {
@@ -288,10 +288,9 @@ export class WebGPURenderer {
 
     const finalPass = enc.beginRenderPass({
       colorAttachments: [{
-        view      : this.sampleCount > 1 && this.msaaTexture ? this.msaaTexture.createView() : canvasTex.createView(),
-        resolveTarget: this.sampleCount > 1 ? canvasTex.createView() : undefined,
+        view      : canvasTex.createView(),
         loadOp    : 'clear',
-        storeOp   : this.sampleCount > 1 ? 'discard' : 'store',
+        storeOp   : 'store',
         clearValue: { r: 0, g: 0, b: 0, a: 1 },
       }],
     });


### PR DESCRIPTION
Fix MSAA sample count mismatch and static previews

- Fixed WebGPURenderer to use `sampleCount: 1` for intermediate layerTextures, as they are used as resolve targets which must be non-multisampled.
- Modified the compositor's final render pass to directly write to the canvas view without resolving, since it runs at `sampleCount: 1` and does not need MSAA.
- Prevented separated and tracer preview canvases from continuously updating with rotation by only copying the main canvas frame once per image load.

---
*PR created automatically by Jules for task [18271694684715295278](https://jules.google.com/task/18271694684715295278) started by @ford442*