### PR TITLE
Remove rotation rate controls and use fixed DEFAULT_RATES

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,6 @@ export default function App() {
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
 
   const [layerAngles, setLayerAngles] = useState<LayerTriple<number>>(DEFAULT_ANGLES);
-  const [rotationRates, setRotationRates] = useState<LayerTriple<number>>(DEFAULT_RATES);
   const [frameRate, setFrameRate] = useState(DEFAULT_FPS);
   const [avgLuminance, setAvgLuminance] = useState(128);
   const [isAutoPlayActive, setIsAutoPlayActive] = useState(true);
@@ -197,9 +196,9 @@ export default function App() {
 
         // Advance each layer's angle by its rotation rate + extension per frame
         angles = [
-          (angles[0] + rotationRates[0] + layerExtensions[0]) % 360,
-          (angles[1] + rotationRates[1] + layerExtensions[1]) % 360,
-          (angles[2] + rotationRates[2] + layerExtensions[2]) % 360,
+          (angles[0] + DEFAULT_RATES[0] + layerExtensions[0]) % 360,
+          (angles[1] + DEFAULT_RATES[1] + layerExtensions[1]) % 360,
+          (angles[2] + DEFAULT_RATES[2] + layerExtensions[2]) % 360,
         ];
 
         setLayerAngles(angles);
@@ -249,20 +248,12 @@ export default function App() {
       if (animFrameRef.current !== null) cancelAnimationFrame(animFrameRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gpuReady, frameRate, rotationRates, layerExtensions, avgLuminance, layerOpacity, tracerIntensity]);
+  }, [gpuReady, frameRate, layerExtensions, avgLuminance, layerOpacity, tracerIntensity]);
 
   const handleAngleChange = useCallback((layer: 0 | 1 | 2, angle: number) => {
     setLayerAngles((prev) => {
       const next: LayerTriple<number> = [...prev] as LayerTriple<number>;
       next[layer] = angle;
-      return next;
-    });
-  }, []);
-
-  const handleRateChange = useCallback((layer: 0 | 1 | 2, rate: number) => {
-    setRotationRates((prev) => {
-      const next: LayerTriple<number> = [...prev] as LayerTriple<number>;
-      next[layer] = rate;
       return next;
     });
   }, []);
@@ -277,7 +268,6 @@ export default function App() {
 
   const handleReset = useCallback(() => {
     setLayerAngles([...DEFAULT_ANGLES] as LayerTriple<number>);
-    setRotationRates([...DEFAULT_RATES] as LayerTriple<number>);
     setFrameRate(DEFAULT_FPS);
   }, []);
 
@@ -377,7 +367,6 @@ export default function App() {
       {/* NUNIF control overlay */}
       <NunifOverlay
         layerAngles={layerAngles}
-        rotationRates={rotationRates}
         layerExtensions={layerExtensions}
         frameRate={frameRate}
         layerOpacity={layerOpacity}
@@ -386,7 +375,6 @@ export default function App() {
         squareCanvas={squareCanvas}
         antialiasEnabled={antialiasEnabled}
         onAngleChange={handleAngleChange}
-        onRateChange={handleRateChange}
         onExtensionChange={handleExtensionChange}
         onFrameRateChange={setFrameRate}
         onLayerOpacityChange={setLayerOpacity}

--- a/src/components/NunifOverlay.tsx
+++ b/src/components/NunifOverlay.tsx
@@ -7,7 +7,6 @@
 
 interface Props {
   layerAngles: [number, number, number];
-  rotationRates: [number, number, number];
   layerExtensions: [number, number, number];
   frameRate: number;
   layerOpacity: number;
@@ -16,7 +15,6 @@ interface Props {
   squareCanvas: boolean;
   antialiasEnabled: boolean;
   onAngleChange: (layer: 0 | 1 | 2, angle: number) => void;
-  onRateChange: (layer: 0 | 1 | 2, rate: number) => void;
   onExtensionChange: (layer: 0 | 1 | 2, extension: number) => void;
   onFrameRateChange: (fps: number) => void;
   onLayerOpacityChange: (opacity: number) => void;
@@ -36,7 +34,6 @@ const LAYER_COLORS: [string, string, string] = ['text-red-400', 'text-violet-400
 
 export function NunifOverlay({
   layerAngles,
-  rotationRates,
   layerExtensions,
   frameRate,
   layerOpacity,
@@ -45,7 +42,6 @@ export function NunifOverlay({
   squareCanvas,
   antialiasEnabled,
   onAngleChange,
-  onRateChange,
   onExtensionChange,
   onFrameRateChange,
   onLayerOpacityChange,
@@ -122,22 +118,6 @@ export function NunifOverlay({
                   max={359}
                   value={layerAngles[i]}
                   onChange={(e) => onAngleChange(i, Number(e.target.value))}
-                  className="w-full accent-current h-1"
-                />
-              </div>
-
-              <div className="flex items-center gap-2">
-                <label className="text-xs text-gray-400 w-16 shrink-0">
-                  Rate&nbsp;
-                  <span className="tabular-nums">{rotationRates[i]}°/f</span>
-                </label>
-                <input
-                  type="range"
-                  min={0}
-                  max={10}
-                  step={0.5}
-                  value={rotationRates[i]}
-                  onChange={(e) => onRateChange(i, Number(e.target.value))}
                   className="w-full accent-current h-1"
                 />
               </div>


### PR DESCRIPTION
## Summary
This PR removes the dynamic rotation rate state management and UI controls, replacing them with fixed `DEFAULT_RATES` values. The rotation rates are no longer user-configurable and are now applied as constants during animation frame updates.

## Key Changes
- Removed `rotationRates` state variable and its setter from App.tsx
- Removed `handleRateChange` callback function that managed rotation rate updates
- Updated animation loop to use `DEFAULT_RATES` directly instead of the state variable
- Removed rotation rate UI controls from NunifOverlay component
- Removed `rotationRates` and `onRateChange` props from NunifOverlay interface
- Updated dependency array in animation effect hook to remove `rotationRates`
- Removed rotation rate reset logic from `handleReset` callback

## Implementation Details
The rotation rates are now treated as immutable configuration constants rather than user-adjustable parameters. During each animation frame, the angle advancement calculation uses `DEFAULT_RATES[i]` directly:
```
angles[i] = (angles[i] + DEFAULT_RATES[i] + layerExtensions[i]) % 360
```

This simplifies the state management while maintaining the same animation behavior, as the rotation rates remain constant throughout the application lifecycle.

https://claude.ai/code/session_01XAbUzWPVSimj3BQJio4ZHj