### PR TITLE
Add COPY_SRC flag to persistence texture for reading

### DIFF
--- a/src/engine/WebGPURenderer.ts
+++ b/src/engine/WebGPURenderer.ts
@@ -254,11 +254,11 @@ export class WebGPURenderer {
       this.msaaTexture = null;
     }
 
-    // Persistence ping-pong textures — both start as RENDER_ATTACHMENT + TEXTURE_BINDING
+    // Persistence ping-pong textures — both start as RENDER_ATTACHMENT + TEXTURE_BINDING + COPY_SRC
     this.persistTextures = [0, 1].map(() => this.device.createTexture({
       size  : [w, h, 1],
       format: this.format,
-      usage : GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+      usage : GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_SRC,
     })) as [GPUTexture, GPUTexture];
 
     this.persistPingPong = 0;


### PR DESCRIPTION
The persistence texture needs the COPY_SRC usage flag to be copied to a buffer for reading its pixel data. This fixes the WebGPU validation error when trying to display the persistence buffer in the tracer preview.

https://claude.ai/code/session_01SRUUnMhVsWmpdUvRrZYnFB