### PR TITLE
Change default tracer hold duration to 0.5 seconds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ export default function App() {
   const [tracerBelow, setTracerBelow] = useState(false);
   const [squareCanvas, setSquareCanvas] = useState(false);
   const [antialiasEnabled, setAntialiasEnabled] = useState(true);
-  const [tracerDuration, setTracerDuration] = useState(50);
+  const [tracerDuration, setTracerDuration] = useState(500);
   const [tracerMode, setTracerMode] = useState(0); // 0 = combined colors, 1 = grey highlight
   const [tracerPreviewFrozen, setTracerPreviewFrozen] = useState(false);
 


### PR DESCRIPTION
Updated the default tracerDuration from 50ms to 500ms (0.5 seconds) for longer persistence of layer overlaps in the tracer visualization.

https://claude.ai/code/session_01SRUUnMhVsWmpdUvRrZYnFB