### PR TITLE
Add blend modes, overlap-based decay, and random image selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,8 @@ export default function App() {
   const [tracerDuration, setTracerDuration] = useState(500);
   const [tracerMode, setTracerMode] = useState(0); // 0 = combined colors, 1 = grey highlight
   const [tracerPreviewFrozen, setTracerPreviewFrozen] = useState(false);
+  const [layerBlendMode, setLayerBlendMode] = useState(0); // 0=alpha, 1=add, 2=subtract, 3=multiply, 4=screen
+  const [tracerBlendMode, setTracerBlendMode] = useState(0); // 0=alpha, 1=add, 2=subtract, 3=multiply, 4=screen
 
   const previewOriginalRef = useRef<HTMLCanvasElement>(null);
   const previewSeparatedRef = useRef<HTMLCanvasElement>(null);
@@ -170,14 +172,15 @@ export default function App() {
     });
   }, [gpuReady, imageList, currentImageIndex]);
 
-  // Auto-play image rotation
+  // Auto-play image rotation (random)
   useEffect(() => {
     if (!isAutoPlayActive || imageList.length === 0) return;
 
     const interval = setInterval(() => {
-      setCurrentImageIndex((prev) => {
+      setCurrentImageIndex(() => {
         hasUpdatedPreviewsForImage.current = false;
-        return (prev + 1) % imageList.length;
+        // Pick random image (may be same as current)
+        return Math.floor(Math.random() * imageList.length);
       });
     }, imageChangeInterval * 1000);
 
@@ -218,6 +221,8 @@ export default function App() {
           tracerDuration,
           tracerBelow,
           tracerMode,
+          layerBlendMode,
+          tracerBlendMode,
         };
 
         rendererRef.current?.render(state);
@@ -303,7 +308,7 @@ export default function App() {
       if (animFrameRef.current !== null) cancelAnimationFrame(animFrameRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gpuReady, frameRate, layerExtensions, avgLuminance, layerOpacity, tracerIntensity, tracerDuration, tracerBelow, tracerMode, tracerPreviewFrozen]);
+  }, [gpuReady, frameRate, layerExtensions, avgLuminance, layerOpacity, tracerIntensity, tracerDuration, tracerBelow, tracerMode, layerBlendMode, tracerBlendMode, tracerPreviewFrozen]);
 
   const handleAngleChange = useCallback((layer: 0 | 1 | 2, angle: number) => {
     setLayerAngles((prev) => {
@@ -443,6 +448,8 @@ export default function App() {
         tracerDuration={tracerDuration}
         tracerBelow={tracerBelow}
         tracerMode={tracerMode}
+        layerBlendMode={layerBlendMode}
+        tracerBlendMode={tracerBlendMode}
         squareCanvas={squareCanvas}
         antialiasEnabled={antialiasEnabled}
         onAngleChange={handleAngleChange}
@@ -453,6 +460,8 @@ export default function App() {
         onTracerDurationChange={setTracerDuration}
         onTracerBelowToggle={setTracerBelow}
         onTracerModeChange={setTracerMode}
+        onLayerBlendModeChange={setLayerBlendMode}
+        onTracerBlendModeChange={setTracerBlendMode}
         onSquareCanvasToggle={setSquareCanvas}
         onAntialiasToggle={(enabled) => {
           setAntialiasEnabled(enabled);

--- a/src/components/NunifOverlay.tsx
+++ b/src/components/NunifOverlay.tsx
@@ -11,6 +11,8 @@ interface Props {
   tracerDuration          : number;
   tracerBelow             : boolean;
   tracerMode              : number;
+  layerBlendMode          : number;
+  tracerBlendMode         : number;
   squareCanvas            : boolean;
   antialiasEnabled        : boolean;
   onAngleChange           : (layer: 0 | 1 | 2, angle: number) => void;
@@ -21,6 +23,8 @@ interface Props {
   onTracerDurationChange  : (v: number) => void;
   onTracerBelowToggle     : (v: boolean) => void;
   onTracerModeChange      : (v: number) => void;
+  onLayerBlendModeChange  : (v: number) => void;
+  onTracerBlendModeChange : (v: number) => void;
   onSquareCanvasToggle    : (v: boolean) => void;
   onAntialiasToggle       : (v: boolean) => void;
   onReset                 : () => void;
@@ -42,6 +46,8 @@ export function NunifOverlay({
   tracerDuration,
   tracerBelow,
   tracerMode,
+  layerBlendMode,
+  tracerBlendMode,
   squareCanvas,
   antialiasEnabled,
   onAngleChange,
@@ -52,6 +58,8 @@ export function NunifOverlay({
   onTracerDurationChange,
   onTracerBelowToggle,
   onTracerModeChange,
+  onLayerBlendModeChange,
+  onTracerBlendModeChange,
   onSquareCanvasToggle,
   onAntialiasToggle,
   onReset,
@@ -217,6 +225,36 @@ export function NunifOverlay({
             >
               {tracerMode === 0 ? '🎨 Colors' : '◻ Grey'}
             </button>
+          </div>
+
+          <div className="flex items-center gap-2 mt-2">
+            <label className="text-xs text-amber-400/80 font-mono whitespace-nowrap">Layer blend:</label>
+            <select
+              value={layerBlendMode}
+              onChange={(e) => onLayerBlendModeChange(Number(e.target.value))}
+              className="text-xs px-2 py-0.5 rounded bg-gray-800 hover:bg-gray-700 border border-amber-500/30 text-white"
+            >
+              <option value={0}>Alpha</option>
+              <option value={1}>Add</option>
+              <option value={2}>Subtract</option>
+              <option value={3}>Multiply</option>
+              <option value={4}>Screen</option>
+            </select>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-amber-400/80 font-mono whitespace-nowrap">Tracer blend:</label>
+            <select
+              value={tracerBlendMode}
+              onChange={(e) => onTracerBlendModeChange(Number(e.target.value))}
+              className="text-xs px-2 py-0.5 rounded bg-gray-800 hover:bg-gray-700 border border-amber-500/30 text-white"
+            >
+              <option value={0}>Alpha</option>
+              <option value={1}>Add</option>
+              <option value={2}>Subtract</option>
+              <option value={3}>Multiply</option>
+              <option value={4}>Screen</option>
+            </select>
           </div>
 
           <button

--- a/src/engine/WebGPURenderer.ts
+++ b/src/engine/WebGPURenderer.ts
@@ -25,14 +25,16 @@ export interface LayerState {
 }
 
 export interface RendererState {
-  layers           : [LayerState, LayerState, LayerState];
-  avgLuminance     : number;
-  layerOpacity?    : number;
-  tracerIntensity? : number;  // 0–1 opacity of the persistence overlay
-  tracerDuration?  : number;  // milliseconds to hold a hit before it fully fades
-  tracerThreshold? : number;  // min alpha to count a layer as "has colour"
-  tracerBelow?     : boolean; // true = render tracer under the 3 colour layers
-  tracerMode?      : number;  // 0 = combined colors, 1 = grey highlight
+  layers            : [LayerState, LayerState, LayerState];
+  avgLuminance      : number;
+  layerOpacity?     : number;
+  tracerIntensity?  : number;  // 0–1 opacity of the persistence overlay
+  tracerDuration?   : number;  // milliseconds to hold a hit before it fully fades
+  tracerThreshold?  : number;  // min alpha to count a layer as "has colour"
+  tracerBelow?      : boolean; // true = render tracer under the 3 colour layers
+  tracerMode?       : number;  // 0 = combined colors, 1 = grey highlight
+  layerBlendMode?   : number;  // 0=alpha, 1=add, 2=subtract, 3=multiply, 4=screen
+  tracerBlendMode?  : number;  // 0=alpha, 1=add, 2=subtract, 3=multiply, 4=screen
 }
 
 /** Column-major mat3x3 for WGSL std140. */
@@ -120,7 +122,7 @@ export class WebGPURenderer {
     this.compositorBGL      = this.createCompositorBGL();
     this.compositorPipeline = this.createCompositorPipeline();
     this.compositorUniformBuf = device.createBuffer({
-      size: 16,
+      size: 24,  // f32 tracerOpacity + f32 tracerBelow + u32 layerBlendMode + u32 tracerBlendMode
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
   }
@@ -397,8 +399,18 @@ export class WebGPURenderer {
     // ── Pass 4: compositor — live layers + persistence → canvas ───────────
     const tracerOpacity = state.tracerIntensity ?? 0.85;
     const tracerBelow   = state.tracerBelow ? 1.0 : 0.0;
-    this.device.queue.writeBuffer(this.compositorUniformBuf, 0,
-      new Float32Array([tracerOpacity, tracerBelow, 0, 0]));
+    const layerBlendMode = state.layerBlendMode ?? 0;
+    const tracerBlendMode = state.tracerBlendMode ?? 0;
+
+    const compositorUniforms = new ArrayBuffer(24);
+    const floatView = new Float32Array(compositorUniforms);
+    const uintView = new Uint32Array(compositorUniforms);
+    floatView[0] = tracerOpacity;
+    floatView[1] = tracerBelow;
+    uintView[2] = layerBlendMode;
+    uintView[3] = tracerBlendMode;
+
+    this.device.queue.writeBuffer(this.compositorUniformBuf, 0, compositorUniforms);
 
     const compBG = this.device.createBindGroup({
       layout : this.compositorBGL,

--- a/src/engine/shaders.ts
+++ b/src/engine/shaders.ts
@@ -283,8 +283,16 @@ fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
     }
   }
 
-  // Decay previous persistence
-  let decayed = prev * pu.decayFactor;
+  // Decay based on overlap intensity
+  // 2 overlaps: slower decay (0.8x), 3 overlaps: faster decay (1.2x)
+  var decayMod = 1.0;
+  if (count == 2) {
+    decayMod = 0.8;
+  } else if (count == 3) {
+    decayMod = 1.2;
+  }
+  let effectiveDecay = pow(pu.decayFactor, decayMod);
+  let decayed = prev * effectiveDecay;
 
   // Keep the stronger one (new collision beats old ghost)
   // If newColor has alpha, use it; otherwise use decayed
@@ -305,10 +313,10 @@ export const compositorFragmentSource = /* wgsl */ `
 @group(0) @binding(4) var persistence: texture_2d<f32>;
 
 struct CompositorUniforms {
-  tracerOpacity : f32,  // how opaque the persistence overlay is (0–1)
-  tracerBelow   : f32,  // 1.0 = composite tracer below layers, 0.0 = above
-  _pad0         : f32,
-  _pad1         : f32,
+  tracerOpacity  : f32,  // how opaque the persistence overlay is (0–1)
+  tracerBelow    : f32,  // 1.0 = composite tracer below layers, 0.0 = above
+  layerBlendMode : u32,  // 0=alpha, 1=add, 2=subtract, 3=multiply, 4=screen
+  tracerBlendMode: u32,  // 0=alpha, 1=add, 2=subtract, 3=multiply, 4=screen
 };
 @group(0) @binding(5) var<uniform> cu : CompositorUniforms;
 
@@ -317,6 +325,36 @@ fn alpha_blend(dst: vec4<f32>, src: vec4<f32>) -> vec4<f32> {
   if (a < 0.0001) { return vec4<f32>(0.0); }
   let rgb = (src.rgb * src.a + dst.rgb * dst.a * (1.0 - src.a)) / a;
   return vec4<f32>(rgb, a);
+}
+
+fn add_blend(dst: vec4<f32>, src: vec4<f32>) -> vec4<f32> {
+  return dst + src;
+}
+
+fn subtract_blend(dst: vec4<f32>, src: vec4<f32>) -> vec4<f32> {
+  return max(dst - src, vec4<f32>(0.0));
+}
+
+fn multiply_blend(dst: vec4<f32>, src: vec4<f32>) -> vec4<f32> {
+  let rgb = dst.rgb * src.rgb;
+  let a = src.a + dst.a * (1.0 - src.a);
+  return vec4<f32>(rgb, a);
+}
+
+fn screen_blend(dst: vec4<f32>, src: vec4<f32>) -> vec4<f32> {
+  let rgb = 1.0 - (1.0 - dst.rgb) * (1.0 - src.rgb);
+  let a = src.a + dst.a * (1.0 - src.a);
+  return vec4<f32>(rgb, a);
+}
+
+fn blend(dst: vec4<f32>, src: vec4<f32>, mode: u32) -> vec4<f32> {
+  switch (mode) {
+    case 1u: { return add_blend(dst, src); }
+    case 2u: { return subtract_blend(dst, src); }
+    case 3u: { return multiply_blend(dst, src); }
+    case 4u: { return screen_blend(dst, src); }
+    default: { return alpha_blend(dst, src); }
+  }
 }
 
 @fragment
@@ -331,16 +369,16 @@ fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
   var col = vec4<f32>(0.0);
   if (cu.tracerBelow > 0.5) {
     // Tracer below — layers render on top of ghosts
-    col = alpha_blend(col, persScaled);
-    col = alpha_blend(col, c2);
-    col = alpha_blend(col, c1);
-    col = alpha_blend(col, c0);
+    col = blend(col, persScaled, cu.tracerBlendMode);
+    col = blend(col, c2, cu.layerBlendMode);
+    col = blend(col, c1, cu.layerBlendMode);
+    col = blend(col, c0, cu.layerBlendMode);
   } else {
     // Tracer above — ghosts render on top of layers (default)
-    col = alpha_blend(col, c2);
-    col = alpha_blend(col, c1);
-    col = alpha_blend(col, c0);
-    col = alpha_blend(col, persScaled);
+    col = blend(col, c2, cu.layerBlendMode);
+    col = blend(col, c1, cu.layerBlendMode);
+    col = blend(col, c0, cu.layerBlendMode);
+    col = blend(col, persScaled, cu.tracerBlendMode);
   }
 
   return col;


### PR DESCRIPTION
Features:
- Implement 5 blend modes for compositing: alpha (default), add, subtract, multiply, screen
- Add independent controls for layer blend mode and tracer blend mode in UI
- Implement overlap-based tracer decay: 2-layer overlaps fade slower (0.8x), 3-layer overlaps fade faster (1.2x)
- Change autoplay to randomly select images instead of cycling sequentially
- Update UI with blend mode dropdown selectors

Modified files:
- src/engine/shaders.ts: Add blend functions and modify compositor/persistence shaders
- src/engine/WebGPURenderer.ts: Add blend mode uniforms to compositor
- src/components/NunifOverlay.tsx: Add blend mode dropdown controls
- src/App.tsx: Add blend mode state, update autoplay logic, pass uniforms to renderer

https://claude.ai/code/session_01SRUUnMhVsWmpdUvRrZYnFB