### PR TITLE
Fix vertex shader uniform mismatch that broke layer rendering and tracer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -358,7 +358,7 @@ export default function App() {
       if (animFrameRef.current !== null) cancelAnimationFrame(animFrameRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gpuReady, frameRate, layerExtensions, avgLuminance, layerOpacity, tracerAboveIntensity, tracerBelowIntensity, tracerAboveDuration, tracerBelowDuration, tracerMode, layerBlendMode, tracerBlendMode, tracerPreviewFrozen, isPaused]);
+  }, [gpuReady, frameRate, layerExtensions, avgLuminance, layerOpacity, tracerAboveIntensity, tracerBelowIntensity, tracerAboveDuration, tracerBelowDuration, tracerMode, layerBlendMode, tracerBlendMode, outputMode, tracerPreviewFrozen, isPaused]);
 
   const handleAngleChange = useCallback((layer: 0 | 1 | 2, angle: number) => {
     setLayerAngles((prev) => {
@@ -425,9 +425,9 @@ export default function App() {
       <div className="absolute bottom-3 right-3 z-30 border border-amber-500/30 rounded overflow-hidden bg-black/40 backdrop-blur-md">
         <canvas
           ref={previewTracerRef}
-          width={150}
-          height={150}
-          style={{ display: 'block', imageRendering: 'pixelated' }}
+          width={300}
+          height={300}
+          style={{ display: 'block', width: '150px', height: '150px', imageRendering: 'auto' }}
         />
         <div className="flex items-center justify-between px-2 py-1">
           <span className="text-xs text-amber-400 font-mono">Tracer</span>

--- a/src/engine/WebGPURenderer.ts
+++ b/src/engine/WebGPURenderer.ts
@@ -40,13 +40,6 @@ export interface RendererState {
   paused?              : boolean; // When true, tracer persistence stops decaying
 }
 
-/** Column-major mat3x3 for WGSL std140. */
-function buildRotationMat3(angleDeg: number): Float32Array {
-  const rad = (angleDeg * Math.PI) / 180;
-  const c = Math.cos(rad), s = Math.sin(rad);
-  return new Float32Array([c, s, 0, 0, -s, c, 0, 0, 0, 0, 1, 0]);
-}
-
 /**
  * Convert tracerDuration (ms) and frameRate (fps) into a per-frame
  * decay multiplier so that after `duration` ms the value reaches ~1/255.
@@ -156,7 +149,7 @@ export class WebGPURenderer {
     });
 
     const rotationBuffer = device.createBuffer({
-      size: 64, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+      size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
     const fragUniformBuffer = device.createBuffer({
       size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
@@ -348,13 +341,12 @@ export class WebGPURenderer {
       const lp    = this.layerPipelines[i];
       const layer = state.layers[i];
 
-      const rotMat = buildRotationMat3(layer.angleDeg);
-      const flipX  = layer.flipX ? 1 : 0;
-      const flipY  = layer.flipY ? 1 : 0;
-      const rotBuf = new ArrayBuffer(64);
-      new Float32Array(rotBuf).set(rotMat);
-      new Uint32Array(rotBuf, 48).set([flipX, flipY]);
-      this.device.queue.writeBuffer(lp.rotationBuffer, 0, rotBuf);
+      const rad    = (layer.angleDeg * Math.PI) / 180;
+      const flipX  = layer.flipX ? 1.0 : 0.0;
+      const flipY  = layer.flipY ? 1.0 : 0.0;
+      const aspect = canvasTex.width / canvasTex.height;
+      this.device.queue.writeBuffer(lp.rotationBuffer, 0,
+        new Float32Array([rad, flipX, flipY, aspect]));
 
       const opacity = state.layerOpacity ?? 1.0;
       this.device.queue.writeBuffer(lp.fragUniformBuffer, 0,
@@ -433,12 +425,11 @@ export class WebGPURenderer {
       pass.setPipeline(this.persistPipeline); pass.setBindGroup(0, bg); pass.draw(6); pass.end();
     };
 
-    // Execute Below Pass
-    runPersistPass(state.tracerBelowDuration ?? 0, this.persistBelowUniformBuf, this.persistBelowTextures);
-    // Execute Above Pass
-    runPersistPass(state.tracerAboveDuration ?? 1000, this.persistAboveUniformBuf, this.persistAboveTextures);
-
-    this.persistPingPong = writeIdx;
+    if (!state.paused) {
+      runPersistPass(state.tracerBelowDuration ?? 0, this.persistBelowUniformBuf, this.persistBelowTextures);
+      runPersistPass(state.tracerAboveDuration ?? 1000, this.persistAboveUniformBuf, this.persistAboveTextures);
+      this.persistPingPong = writeIdx;
+    }
 
     // ── Pass 4: compositor ───────────
     const tracerAboveOp = state.tracerAboveIntensity ?? 0.85;
@@ -468,8 +459,8 @@ export class WebGPURenderer {
         { binding: 1, resource: this.layerTextures[0].createView() },
         { binding: 2, resource: this.layerTextures[1].createView() },
         { binding: 3, resource: this.layerTextures[2].createView() },
-        { binding: 4, resource: this.persistBelowTextures[writeIdx]!.createView() }, // Binding 4: Below
-        { binding: 5, resource: this.persistAboveTextures[writeIdx]!.createView() }, // Binding 5: Above
+        { binding: 4, resource: this.persistBelowTextures[this.persistPingPong]!.createView() }, // Binding 4: Below
+        { binding: 5, resource: this.persistAboveTextures[this.persistPingPong]!.createView() }, // Binding 5: Above
         { binding: 6, resource: { buffer: this.compositorUniformBuf } },
       ],
     });


### PR DESCRIPTION
## Summary

- **Root cause fix**: The vertex shader expected a 16-byte struct `{ angleRad, flipX, flipY, aspect }` but the renderer was writing a 48-byte column-major mat3×3. As a result `u.angleRad` received `cos(angle)` instead of the angle itself, and `u.aspect` was always `0.0`. Division by zero in the UV calculation produced NaN/inf Y-coordinates that clamped to the image edge — all three layers rendered the same degenerate strip, the persistence detector never saw valid three-way overlaps, and the tracer produced nothing.
- **Paused state now works**: Persistence passes are skipped when `state.paused = true`, freezing tracer decay; the compositor reads from `this.persistPingPong` so it stays consistent with either branch.
- **`outputMode` dep added**: Animation loop `useEffect` was missing `outputMode` in its dependency array, so changes to that control had no effect until another dep changed.
- **Tracer preview sharpness**: Canvas bumped from 150×150 to 300×300 internal resolution (displayed at 150px CSS) for crisp HiDPI output.

## Test plan

- [ ] Verify all three colour layers render correctly with proper rotation and aspect-ratio correction
- [ ] Confirm tracer ghost/persistence accumulates and composites visibly onto the main canvas
- [ ] Toggle Pause — tracer should freeze in place; Resume should continue decay from where it stopped
- [ ] Change Output Mode — should take effect immediately without requiring another control change
- [ ] Check tracer preview thumbnail is sharper than before on a HiDPI display

---
_Generated by [Claude Code](https://claude.ai/code/session_016Yf7nctfR6N8FR1EBTdhNx)_