### PR TITLE
HDR intermediates (rgba16float) + uncap tracer preview rate

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,9 @@ export default function App() {
   const previewOriginalRef = useRef<HTMLCanvasElement>(null);
   const previewSeparatedRef = useRef<HTMLCanvasElement>(null);
   const previewTracerRef = useRef<HTMLCanvasElement>(null);
+  // Reusable 256×256 offscreen canvas — avoids createImageBitmap latency
+  // by letting us putImageData once and drawImage-scale to the visible canvas.
+  const tracerScratchRef = useRef<HTMLCanvasElement | null>(null);
   const capturePreviewAfterRender = useRef(false);
   const animAnglesRef = useRef<LayerTriple<number>>(DEFAULT_ANGLES);
   const lastAngleSyncRef = useRef(0);
@@ -285,7 +288,6 @@ export default function App() {
 
     const msPerFrame = 1000 / frameRate;
     let last = performance.now();
-    let lastTracerPreview = 0;
 
     function loop(now: number) {
       const delta = now - last;
@@ -341,25 +343,27 @@ export default function App() {
           }
         }
 
-        // Tracer preview: throttle to ~5fps, read back the small composited
-        // preview texture instead of the full-resolution persistence texture.
-        // No per-tick buffer allocation, no JS downscaling loop.
-        if (!tracerPreviewFrozen && now - lastTracerPreview > 200) {
-          lastTracerPreview = now;
+        // Tracer preview: issue a readback every frame. readPreviewPixels
+        // self-serializes via previewReadPending, so requests issued while a
+        // prior map is in flight are dropped cheaply — output rate naturally
+        // matches the GPU/readback latency rather than a fixed wall clock.
+        if (!tracerPreviewFrozen) {
           const previewTracer = previewTracerRef.current;
           if (previewTracer && rendererRef.current) {
             const sz = WebGPURenderer.PREVIEW_SIZE;
             rendererRef.current.readPreviewPixels((data) => {
-              // Scale the 256×256 GPU result to fill the preview canvas using
-              // createImageBitmap (browser-native, off-main-thread capable).
-              const imageData = new ImageData(data, sz, sz);
-              createImageBitmap(imageData).then((bmp) => {
-                const ctx = previewTracer.getContext('2d');
-                if (ctx) {
-                  ctx.drawImage(bmp, 0, 0, previewTracer.width, previewTracer.height);
-                }
-                bmp.close();
-              });
+              let scratch = tracerScratchRef.current;
+              if (!scratch) {
+                scratch = document.createElement('canvas');
+                scratch.width = sz;
+                scratch.height = sz;
+                tracerScratchRef.current = scratch;
+              }
+              const sctx = scratch.getContext('2d');
+              const dctx = previewTracer.getContext('2d');
+              if (!sctx || !dctx) return;
+              sctx.putImageData(new ImageData(data, sz, sz), 0, 0);
+              dctx.drawImage(scratch, 0, 0, previewTracer.width, previewTracer.height);
             });
           }
         }

--- a/src/engine/WebGPURenderer.ts
+++ b/src/engine/WebGPURenderer.ts
@@ -97,11 +97,14 @@ export class WebGPURenderer {
   /** Size of the composited preview texture (fixed, independent of canvas/tracerScale). */
   static readonly PREVIEW_SIZE = 256;
 
-  private device      : GPUDevice;
-  private context     : GPUCanvasContext;
-  private format      : GPUTextureFormat;
-  private sampler     : GPUSampler;
-  private sampleCount : number = 4;
+  private device         : GPUDevice;
+  private context        : GPUCanvasContext;
+  private format         : GPUTextureFormat;
+  /** HDR format used for all intermediate textures (layers, persistence, MSAA).
+   *  rgba16float is renderable + blendable in WebGPU core — no feature flag needed. */
+  private internalFormat : GPUTextureFormat = 'rgba16float';
+  private sampler        : GPUSampler;
+  private sampleCount    : number = 4;
 
   // Layer passes
   private layerPipelines : LayerPipeline[] = [];
@@ -191,7 +194,7 @@ export class WebGPURenderer {
       fragment: {
         module     : device.createShaderModule({ code: fragmentSource }),
         entryPoint : 'main',
-        targets    : [{ format: this.format }],
+        targets    : [{ format: this.internalFormat }],
       },
       primitive  : { topology: 'triangle-list' },
       multisample: { count: this.sampleCount },
@@ -229,7 +232,7 @@ export class WebGPURenderer {
       fragment: {
         module     : device.createShaderModule({ code: persistenceFragmentSource }),
         entryPoint : 'main',
-        targets    : [{ format: this.format }],
+        targets    : [{ format: this.internalFormat }],
       },
       primitive  : { topology: 'triangle-list' },
       multisample: { count: 1 },
@@ -284,7 +287,7 @@ export class WebGPURenderer {
     // Layer intermediate textures (scaled by layerScale)
     this.layerTextures = [0, 1, 2].map(() => this.device.createTexture({
       size       : [layerW, layerH, 1],
-      format     : this.format,
+      format     : this.internalFormat,
       usage      : GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
       sampleCount: 1,
     }));
@@ -293,7 +296,7 @@ export class WebGPURenderer {
     if (this.sampleCount > 1) {
       this.msaaTexture = this.device.createTexture({
         size       : [w, h, 1],
-        format     : this.format,
+        format     : this.internalFormat,
         sampleCount: this.sampleCount,
         usage      : GPUTextureUsage.RENDER_ATTACHMENT,
       });
@@ -303,7 +306,7 @@ export class WebGPURenderer {
 
     // Persistence ping-pong textures — scaled by tracerScale
     const createPersistTex = () => this.device.createTexture({
-      size  : [tracerW, tracerH, 1], format: this.format,
+      size  : [tracerW, tracerH, 1], format: this.internalFormat,
       usage : GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_SRC,
     });
 


### PR DESCRIPTION
## Summary
- Switch layer, persistence, and MSAA intermediate textures to `rgba16float` for HDR accumulation — smoother tracer decay and wider effective color range. No WebGPU feature flag required (rgba16float is renderable + blendable + filterable in core). Canvas swapchain and the small preview readback texture stay at the swapchain format.
- Remove the 200ms wall-clock throttle on the tracer preview. `readPreviewPixels` already self-serializes via `previewReadPending`, so the throttle was just capping the rate to ~5fps unnecessarily.
- Replace per-frame `createImageBitmap` with a cached 256×256 scratch canvas + `putImageData`/`drawImage` to skip the async decode round-trip.

## Test plan
- [ ] Confirm WebGPU init still succeeds in Chrome 113+
- [ ] Verify tracer preview now updates much more frequently
- [ ] Verify color/decay smoothness on the main canvas (HDR intermediates)
- [ ] MSAA toggle still works (msaaTexture is now rgba16float to match resolve target)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULzY5bbrEC91DdnuYqPbN9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tracer preview now updates at full frame rate instead of throttled rate.
  * Enhanced rendering quality through HDR color format support for intermediate rendering layers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Chromashift/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->