### PR TITLE
Point VITE_UPSCALER_BASE to js.1ink.us model mirror

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,13 @@
 # Base URL hosting Real-ESRGAN / Real-CUGAN TF.js model files.
+# Copy this file to .env.local and set the value below.
 #
-# Layout expected on the host:
-#   ${VITE_UPSCALER_BASE}/realesrgan/general_plus-64/model.json (+ .bin shards)
-#   ${VITE_UPSCALER_BASE}/realcugan/2x-conservative-64/model.json (+ .bin shards)
-#   ...
+# Files expected under this base (all with CORS headers):
+#   /realesrgan/general_fast-64/model.json  + group1-shard1of1.bin
+#   /realesrgan/general_plus-64/model.json  + group1-shard{1..8}of8.bin
+#   /realesrgan/anime_fast-64/model.json    + group1-shard1of1.bin
+#   /realesrgan/anime_plus-64/model.json    + group1-shard{1..3}of3.bin
+#   /realcugan/2x-conservative-64/model.json + group1-shard1of1.bin
+#   /realcugan/4x-conservative-64/model.json + group1-shard1of1.bin
 #
-# Mirror the files from upscale.chino.icu (xororz/web-realesrgan) onto your
-# own server. CORS headers must allow the Chromashift origin.
+# Models are cached in IndexedDB after first download.
 VITE_UPSCALER_BASE=https://js.1ink.us


### PR DESCRIPTION
All six model directories are live at https://js.1ink.us with Access-Control-Allow-Origin: * confirmed. .env.example updated with the full file layout. .env.local is gitignored (*.local rule).