### PR TITLE
Force opaque canvas to prevent see-through to desktop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -599,6 +599,7 @@ export default function App() {
           position: 'absolute',
           imageRendering: 'pixelated',
           display: 'block',
+          background: '#000',
         }}
       />
 

--- a/src/engine/WebGPURenderer.ts
+++ b/src/engine/WebGPURenderer.ts
@@ -574,7 +574,11 @@ export class WebGPURenderer {
         view      : canvasTex.createView(),
         loadOp    : 'clear',
         storeOp   : 'store',
-        clearValue: { r: 0, g: 0, b: 0, a: 0 },  // Transparent background, not opaque black
+        // Opaque clear. alphaMode:'opaque' on the swapchain should already
+        // force this, but some browser+GPU combos don't honour it and let
+        // the compositor see straight through to whatever's behind the
+        // browser window when rendered alpha is 0.
+        clearValue: { r: 0, g: 0, b: 0, a: 1 },
       }],
     });
     finalPass.setPipeline(this.compositorPipeline);


### PR DESCRIPTION
The final compositor pass was clearing the canvas to {r:0,g:0,b:0,a:0} on the assumption that alphaMode:'opaque' on the swapchain would ignore the alpha channel. Some browser+GPU combinations don't honour that fully and let the OS compositor see straight through the canvas to whatever's behind the browser window when the rendered alpha is 0.

Clear to opaque black (a=1) and add background:#000 on the canvas element as a defensive backstop in case any future pass leaks transparency.