### PR TITLE
Force opaque alpha in compositor shader output

### DIFF
--- a/src/engine/shaders.ts
+++ b/src/engine/shaders.ts
@@ -434,7 +434,11 @@ fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
     finalCol = blend(finalCol, pAboveScaled, cu.tracerBlendMode);
   }
 
-  return finalCol;
+    // Force opaque output. Without this, no-layer / no-tracer regions
+    // produce alpha=0 pixels and some browser/GPU combos let the OS
+    // compositor see through the canvas to whatever is behind the browser
+    // window, even though alphaMode is 'opaque' on the swapchain.
+    return vec4<f32>(finalCol.rgb, 1.0);
 }
 `;
 


### PR DESCRIPTION
The clear value and CSS background were not enough. The compositor's draw call overwrites the canvas with whatever the shader computes, and when no layers/tracers are visible at a pixel the shader was outputting vec4(0,0,0,0) — alpha=0. Combined with browser/GPU compositor bugs that don't fully honour swapchain alphaMode:'opaque', this let the OS show through to whatever was behind the browser window.

Set alpha=1 on the final return so the canvas drawing buffer is opaque regardless of upstream blending.