### PR TITLE
fix(crop): map CR0P bands from raw luminance to match reference

### DIFF
--- a/src/engine/shaders.ts
+++ b/src/engine/shaders.ts
@@ -125,16 +125,19 @@ fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
     else if (lum > 190.0) { result = vec4<f32>(band_gradient(lum, 190.0, 209.0, 0.0, 10.0, 1.0, 0.40, 0.55), 1.0); }
   } else if (fragUniforms.colorMode >= 1.5) {
     // --- CROP MODE (2.0) / CROP NUNIF2 (3.0) ---
-    // Luminance adjustment: lum += (128 + |avgLum - 128| / 2) / 2
-    let adj       = lum + (128.0 + abs(fragUniforms.avgLuminance - 128.0) * 0.5) * 0.5;
     let isNunif2  = fragUniforms.colorMode > 2.5;
+    // CR0P (mode 2) maps pixels straight from raw luminance so its bands line up
+    // exactly with the go.1ink.us/chromashift reference. NUNIF2 (mode 3) keeps the
+    // luminance lift: lum += (128 + |avgLum - 128| / 2) / 2.
+    let adj       = lum + (128.0 + abs(fragUniforms.avgLuminance - 128.0) * 0.5) * 0.5;
+    let bandLum   = select(lum, adj, isNunif2);
     let nonAlpha  = select(1.0, 0.5, isNunif2);   // NUNIF2 Layer 1 opacity = 0.5
     let darkAlpha = select(0.0, 0.1, isNunif2);
-    if (adj >= 229.0) {
+    if (bandLum >= 229.0) {
       result = vec4<f32>(0.753, 0.753, 0.753, nonAlpha);
-    } else if (adj >= 209.0) {
+    } else if (bandLum >= 209.0) {
       result = vec4<f32>(1.0, 0.627, 0.0, nonAlpha);
-    } else if (adj >= 190.0) {
+    } else if (bandLum >= 190.0) {
       result = vec4<f32>(1.0, 0.0, 0.0, nonAlpha);
     } else {
       result = vec4<f32>(0.0, 0.0, 0.0, darkAlpha);
@@ -223,15 +226,18 @@ fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
     else if (lum > 158.0 && lum <= 177.0) { result = vec4<f32>(band_gradient(lum, 158.0, 177.0, 220.0, 255.0, 1.0, 0.38, 0.50), 1.0); }
   } else if (fragUniforms.colorMode >= 1.5) {
     // --- CROP MODE (2.0) / CROP NUNIF2 (3.0) ---
-    let adj       = lum + (128.0 + abs(fragUniforms.avgLuminance - 128.0) * 0.5) * 0.5;
     let isNunif2  = fragUniforms.colorMode > 2.5;
+    // CR0P (mode 2) uses raw luminance to match the go.1ink.us/chromashift reference;
+    // NUNIF2 (mode 3) keeps its luminance lift.
+    let adj       = lum + (128.0 + abs(fragUniforms.avgLuminance - 128.0) * 0.5) * 0.5;
+    let bandLum   = select(lum, adj, isNunif2);
     let nonAlpha  = select(1.0, 0.777, isNunif2);  // NUNIF2 Layer 2 opacity = 0.777
     let darkAlpha = select(0.0, 0.1, isNunif2);
-    if (adj >= 177.0 && adj < 190.0) {
+    if (bandLum >= 177.0 && bandLum < 190.0) {
       result = vec4<f32>(0.502, 0.0, 0.502, nonAlpha);
-    } else if (adj >= 161.0 && adj < 177.0) {
+    } else if (bandLum >= 161.0 && bandLum < 177.0) {
       result = vec4<f32>(0.0, 0.0, 0.545, nonAlpha);
-    } else if (adj >= 158.0 && adj < 161.0) {
+    } else if (bandLum >= 158.0 && bandLum < 161.0) {
       result = vec4<f32>(0.0, 0.0, 1.0, nonAlpha);
     } else {
       result = vec4<f32>(0.0, 0.0, 0.0, darkAlpha);
@@ -307,15 +313,18 @@ fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
     else if (lum > 125.0 && lum <= 145.0) { result = vec4<f32>(band_gradient(lum, 125.0, 145.0, 50.0, 90.0, 1.0, 0.40, 0.52), 1.0); }
   } else if (fragUniforms.colorMode >= 1.5) {
     // --- CROP MODE (2.0) / CROP NUNIF2 (3.0) ---
-    let adj       = lum + (128.0 + abs(fragUniforms.avgLuminance - 128.0) * 0.5) * 0.5;
     let isNunif2  = fragUniforms.colorMode > 2.5;
+    // CR0P (mode 2) uses raw luminance to match the go.1ink.us/chromashift reference;
+    // NUNIF2 (mode 3) keeps its luminance lift.
+    let adj       = lum + (128.0 + abs(fragUniforms.avgLuminance - 128.0) * 0.5) * 0.5;
+    let bandLum   = select(lum, adj, isNunif2);
     let nonAlpha  = select(1.0, 0.777, isNunif2);  // NUNIF2 Layer 3 opacity = 0.777
     let darkAlpha = select(0.0, 0.1, isNunif2);
-    if (adj >= 145.0 && adj < 158.0) {
+    if (bandLum >= 145.0 && bandLum < 158.0) {
       result = vec4<f32>(0.0, 0.502, 0.0, nonAlpha);
-    } else if (adj >= 128.0 && adj < 145.0) {
+    } else if (bandLum >= 128.0 && bandLum < 145.0) {
       result = vec4<f32>(0.502, 1.0, 0.0, nonAlpha);
-    } else if (adj >= 125.0 && adj < 128.0) {
+    } else if (bandLum >= 125.0 && bandLum < 128.0) {
       result = vec4<f32>(1.0, 1.0, 0.0, nonAlpha);
     } else {
       result = vec4<f32>(0.0, 0.0, 0.0, darkAlpha);


### PR DESCRIPTION
## What

Aligns the **CR0P** color mode (`colorMode 2`) with how the reference build at `go.1ink.us/chromashift` extrapolates colors.

## Why

I compared the reference build's color extrapolation against our CR0P mode:

- **Reference (`go.1ink.us/chromashift`)** maps each pixel's output color straight from its **raw BT.709 luminance** into the band thresholds (229/209/190, 190/177/158, 158/145/125). It happens to use smooth HSL `band_gradient` fills — identical to our existing "Vivid" mode (`colorMode 1`).
- **Our CR0P mode** kept its flat palette but selected bands from an **adjusted** luminance:
  `adj = lum + (128 + |avg − 128| / 2) / 2`
  At neutral `avg` this lifts luminance by ~64, so CR0P's bands landed on entirely different pixels than the reference.

Per the chosen direction ("same colors, reference luminance mapping"), CR0P now selects its bands from **raw `lum`**, keeping its distinct flat palette (grey / orange / red, violet / blue, green / yellow). This makes CR0P color the **same pixels** as the reference, just posterized into flat blocks instead of gradients.

## Scope

- **CR0P (mode 2):** now uses raw luminance.
- **NUNIF2 (mode 3):** **unchanged** — it keeps its existing luminance lift (`adj`), since only CR0P was in scope. The shared branch selects between them with `select(lum, adj, isNunif2)`.

## Changes

- `src/engine/shaders.ts` — all three layer fragment shaders (Red/Orange, Violet/Blue, Green/Yellow): introduce `bandLum = select(lum, adj, isNunif2)` and drive the CROP band thresholds from it.

## Verification

- `npm run build` (tsc + vite) passes.

https://claude.ai/code/session_01WnYUwtwiFafiWG6TMcQhy2

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnYUwtwiFafiWG6TMcQhy2)_