### PR TITLE
Add waifu2x swin_unet (ONNX) upscaler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tensorflow/tfjs": "^4.22.0",
         "@tensorflow/tfjs-backend-webgl": "^4.22.0",
         "@tensorflow/tfjs-backend-webgpu": "^4.22.0",
+        "onnxruntime-web": "^1.26.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
       },
@@ -1031,6 +1032,69 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
@@ -2991,6 +3055,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -3137,6 +3207,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -3794,6 +3870,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/onnxruntime-common": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.26.0.tgz",
+      "integrity": "sha512-qVyMR4lcWgbkc4getFV+GQijsTnbg/siteoqcDwa3sI/LxbrMSNw4ePyvCq/ymdQaRomCA7YuWmhzsswxvymdw==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0.tgz",
+      "integrity": "sha512-LbRr/8zZt2xilI2smrVQGGKINo0U46i8qJp+UXyMBGfqN7KjnH1BiwCwLwyNIVV4i9CKFv7Sf4PwLKWnT8/bEA==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.26.0",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3897,6 +3999,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
     "node_modules/playwright": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
@@ -3982,6 +4090,36 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tensorflow/tfjs": "^4.22.0",
     "@tensorflow/tfjs-backend-webgl": "^4.22.0",
     "@tensorflow/tfjs-backend-webgpu": "^4.22.0",
+    "onnxruntime-web": "^1.26.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -581,6 +581,16 @@ export default function App() {
     if (parts[0] === 'realesrgan') {
       return { kind: 'realesrgan', variant: parts[1] as UpscaleModel extends { kind: 'realesrgan'; variant: infer V } ? V : never };
     }
+    if (parts[0] === 'swin_unet') {
+      // swin_unet:<style>:<scale>:<noise>
+      return {
+        kind: 'swin_unet',
+        style: parts[1] as 'art' | 'art_scan' | 'photo',
+        scale: Number(parts[2]) as 1 | 2 | 4,
+        noise: Number(parts[3]) as -1 | 0 | 1 | 2 | 3,
+        tileSize: 256,
+      };
+    }
     return { kind: 'realcugan', factor: Number(parts[1]) as 2 | 4, denoise: parts[2] as 'conservative' | '0x' | '1x' | '2x' | '3x' };
   }, []);
 

--- a/src/components/NunifOverlay.tsx
+++ b/src/components/NunifOverlay.tsx
@@ -201,20 +201,77 @@ export function NunifOverlay({
 
       {/* ========== UPSCALE ========== */}
       <div className="panel-3d space-y-2">
-        <div className="text-[10px] text-amber-300 font-mono uppercase tracking-wider">🔍 Upscale (Real-ESRGAN / Real-CUGAN)</div>
-        <select
-          value={upscaleModel}
-          onChange={(e) => onUpscaleModelChange(e.target.value)}
-          disabled={upscaleBusy}
-          className="w-full text-xs px-2 py-1 rounded bg-zinc-800 border border-amber-500/30 text-amber-200 disabled:opacity-50"
-        >
-          <option value="realesrgan:general_plus">Real-ESRGAN general_plus (4×, photo)</option>
-          <option value="realesrgan:general_fast">Real-ESRGAN general_fast (4×, photo, fast)</option>
-          <option value="realesrgan:anime_plus">Real-ESRGAN anime_plus (4×, anime)</option>
-          <option value="realesrgan:anime_fast">Real-ESRGAN anime_fast (4×, anime, fast)</option>
-          <option value="realcugan:2:conservative">Real-CUGAN 2× conservative</option>
-          <option value="realcugan:4:conservative">Real-CUGAN 4× conservative</option>
-        </select>
+        <div className="text-[10px] text-amber-300 font-mono uppercase tracking-wider">🔍 Upscale (Real-ESRGAN / waifu2x)</div>
+        {(() => {
+          const isSwin = upscaleModel.startsWith('swin_unet');
+          const swinParts = isSwin ? upscaleModel.split(':') : [];
+          const swinStyle = swinParts[1] ?? 'art';
+          const swinScale = swinParts[2] ?? '2';
+          const swinNoise = swinParts[3] ?? '-1';
+          const selectClass = 'w-full text-xs px-2 py-1 rounded bg-zinc-800 border border-amber-500/30 text-amber-200 disabled:opacity-50';
+          const composeSwin = (style: string, scale: string, noise: string) => {
+            // scale 1× (denoise-only) requires a noise level
+            const n = scale === '1' && noise === '-1' ? '0' : noise;
+            return `swin_unet:${style}:${scale}:${n}`;
+          };
+          return (
+            <>
+              <select
+                value={isSwin ? `swin_unet:${swinStyle}` : upscaleModel}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  onUpscaleModelChange(
+                    v.startsWith('swin_unet') ? composeSwin(v.split(':')[1], swinScale, swinNoise) : v,
+                  );
+                }}
+                disabled={upscaleBusy}
+                className={selectClass}
+              >
+                <optgroup label="Real-ESRGAN / Real-CUGAN (TF.js)">
+                  <option value="realesrgan:general_plus">Real-ESRGAN general_plus (4×, photo)</option>
+                  <option value="realesrgan:general_fast">Real-ESRGAN general_fast (4×, photo, fast)</option>
+                  <option value="realesrgan:anime_plus">Real-ESRGAN anime_plus (4×, anime)</option>
+                  <option value="realesrgan:anime_fast">Real-ESRGAN anime_fast (4×, anime, fast)</option>
+                  <option value="realcugan:2:conservative">Real-CUGAN 2× conservative</option>
+                  <option value="realcugan:4:conservative">Real-CUGAN 4× conservative</option>
+                </optgroup>
+                <optgroup label="waifu2x swin_unet (ONNX)">
+                  <option value="swin_unet:art">swin_unet art (illustration)</option>
+                  <option value="swin_unet:art_scan">swin_unet art_scan (scanned art)</option>
+                  <option value="swin_unet:photo">swin_unet photo</option>
+                </optgroup>
+              </select>
+              {isSwin && (
+                <div className="flex gap-2">
+                  <select
+                    value={swinScale}
+                    onChange={(e) => onUpscaleModelChange(composeSwin(swinStyle, e.target.value, swinNoise))}
+                    disabled={upscaleBusy}
+                    className={selectClass}
+                    title="Output scale"
+                  >
+                    <option value="1">1× (denoise only)</option>
+                    <option value="2">2×</option>
+                    <option value="4">4×</option>
+                  </select>
+                  <select
+                    value={swinScale === '1' && swinNoise === '-1' ? '0' : swinNoise}
+                    onChange={(e) => onUpscaleModelChange(composeSwin(swinStyle, swinScale, e.target.value))}
+                    disabled={upscaleBusy}
+                    className={selectClass}
+                    title="Noise reduction level"
+                  >
+                    {swinScale !== '1' && <option value="-1">No denoise</option>}
+                    <option value="0">Denoise 0</option>
+                    <option value="1">Denoise 1</option>
+                    <option value="2">Denoise 2</option>
+                    <option value="3">Denoise 3</option>
+                  </select>
+                </div>
+              )}
+            </>
+          );
+        })()}
         <div className="flex gap-2">
           <button
             onClick={onUpscaleSource}

--- a/src/engine/Upscaler.ts
+++ b/src/engine/Upscaler.ts
@@ -7,10 +7,16 @@
  */
 
 import type { UpscalerRequest, UpscalerResponse } from './upscaler.worker';
+import type { NunifRequest, NunifResponse, NunifStyle } from './nunif.worker';
+
+// Default host for the waifu2x/swin_unet ONNX models (reuses the nunif app's
+// model tree). Override with VITE_NUNIF_BASE to self-host.
+const NUNIF_DEFAULT_BASE = 'https://test.1ink.us/nunif';
 
 export type UpscaleModel =
   | { kind: 'realesrgan'; variant: 'general_plus' | 'general_fast' | 'anime_plus' | 'anime_fast' }
-  | { kind: 'realcugan'; factor: 2 | 4; denoise: 'conservative' | '0x' | '1x' | '2x' | '3x' };
+  | { kind: 'realcugan'; factor: 2 | 4; denoise: 'conservative' | '0x' | '1x' | '2x' | '3x' }
+  | { kind: 'swin_unet'; style: NunifStyle; scale: 1 | 2 | 4; noise: -1 | 0 | 1 | 2 | 3; tileSize: number };
 
 export interface UpscaleResult {
   pixels: Uint8ClampedArray;
@@ -26,7 +32,8 @@ export interface UpscaleProgress {
 const TILE_SIZE = 64;
 
 export class Upscaler {
-  private worker: Worker | null = null;
+  private tfWorker: Worker | null = null;     // TF.js Real-ESRGAN / Real-CUGAN
+  private onnxWorker: Worker | null = null;    // onnxruntime-web swin_unet
   private busy = false;
 
   /** True if a job is currently running. */
@@ -46,33 +53,35 @@ export class Upscaler {
     if (this.busy) throw new Error('Upscaler is already running a job');
     this.busy = true;
 
-    const baseUrl = (import.meta.env.VITE_UPSCALER_BASE as string | undefined)?.replace(/\/$/, '') ?? '';
-    if (!baseUrl) {
-      this.busy = false;
-      throw new Error(
-        'VITE_UPSCALER_BASE is not set. Configure it to the URL hosting realesrgan/ and realcugan/ model files.',
-      );
-    }
+    const buffer = pixels.buffer.slice(pixels.byteOffset, pixels.byteOffset + pixels.byteLength) as ArrayBuffer;
 
-    if (!this.worker) {
-      this.worker = new Worker(new URL('./upscaler.worker.ts', import.meta.url), { type: 'module' });
+    let worker: Worker;
+    let req: UpscalerRequest | NunifRequest;
+    if (model.kind === 'swin_unet') {
+      const baseUrl = ((import.meta.env.VITE_NUNIF_BASE as string | undefined) ?? NUNIF_DEFAULT_BASE).replace(/\/$/, '');
+      this.onnxWorker ??= new Worker(new URL('./nunif.worker.ts', import.meta.url), { type: 'module' });
+      worker = this.onnxWorker;
+      req = {
+        kind: 'swin_unet', style: model.style, scale: model.scale, noise: model.noise,
+        tileSize: model.tileSize, width, height, pixels: buffer, baseUrl,
+      };
+    } else {
+      const baseUrl = (import.meta.env.VITE_UPSCALER_BASE as string | undefined)?.replace(/\/$/, '') ?? '';
+      if (!baseUrl) {
+        this.busy = false;
+        throw new Error(
+          'VITE_UPSCALER_BASE is not set. Configure it to the URL hosting realesrgan/ and realcugan/ model files.',
+        );
+      }
+      this.tfWorker ??= new Worker(new URL('./upscaler.worker.ts', import.meta.url), { type: 'module' });
+      worker = this.tfWorker;
+      req = model.kind === 'realesrgan'
+        ? { kind: 'realesrgan', variant: model.variant, tileSize: TILE_SIZE, width, height, pixels: buffer, baseUrl }
+        : { kind: 'realcugan', factor: model.factor, denoise: model.denoise, tileSize: TILE_SIZE, width, height, pixels: buffer, baseUrl };
     }
-    const worker = this.worker;
-
-    const req: UpscalerRequest = model.kind === 'realesrgan'
-      ? {
-          kind: 'realesrgan', variant: model.variant, tileSize: TILE_SIZE,
-          width, height, pixels: pixels.buffer.slice(pixels.byteOffset, pixels.byteOffset + pixels.byteLength) as ArrayBuffer,
-          baseUrl,
-        }
-      : {
-          kind: 'realcugan', factor: model.factor, denoise: model.denoise, tileSize: TILE_SIZE,
-          width, height, pixels: pixels.buffer.slice(pixels.byteOffset, pixels.byteOffset + pixels.byteLength) as ArrayBuffer,
-          baseUrl,
-        };
 
     return new Promise<UpscaleResult>((resolve, reject) => {
-      const onMsg = (e: MessageEvent<UpscalerResponse>) => {
+      const onMsg = (e: MessageEvent<UpscalerResponse | NunifResponse>) => {
         const msg = e.data;
         if (msg.kind === 'progress') {
           onProgress?.({ progress: msg.progress, info: msg.info });
@@ -96,8 +105,10 @@ export class Upscaler {
   }
 
   destroy(): void {
-    this.worker?.terminate();
-    this.worker = null;
+    this.tfWorker?.terminate();
+    this.onnxWorker?.terminate();
+    this.tfWorker = null;
+    this.onnxWorker = null;
     this.busy = false;
   }
 }

--- a/src/engine/nunif.worker.ts
+++ b/src/engine/nunif.worker.ts
@@ -1,0 +1,427 @@
+/**
+ * nunif / waifu2x Web Worker (ONNX Runtime Web)
+ *
+ * Ports the swin_unet super-resolution pipeline from nagadomi's nunif web app
+ * (https://github.com/nagadomi/nunif, MIT) to run inside Chromashift.
+ *
+ * Unlike upscaler.worker.ts (TF.js Real-ESRGAN/Real-CUGAN), this worker runs
+ * the original waifu2x `swin_unet` ONNX models via onnxruntime-web. It mirrors
+ * the upstream tiled renderer: cumulative seam/border blending, edge/reflection
+ * padding via helper ONNX models, and a single-color tile fast-path.
+ *
+ * Scope (per project decision): RGB only — no alpha channel handling and no TTA.
+ *
+ * Models are fetched from `${baseUrl}/models/swin_unet/${style}/${method}.onnx`
+ * and helpers from `${baseUrl}/models/utils/${name}.onnx`. The shared response
+ * shape ({progress|done|error}) matches upscaler.worker.ts so the main-thread
+ * Upscaler can treat both workers identically.
+ */
+
+/// <reference lib="webworker" />
+
+import * as ort from 'onnxruntime-web';
+
+declare const self: DedicatedWorkerGlobalScope;
+
+// onnxruntime-web fetches its wasm binaries at runtime; point them at the CDN
+// build matching the installed package version so no extra assets are bundled.
+ort.env.wasm.wasmPaths = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ort.env.versions.web}/dist/`;
+ort.env.wasm.numThreads = 1; // avoids requiring cross-origin isolation (COOP/COEP)
+ort.env.wasm.proxy = false;
+
+export type NunifStyle = 'art' | 'art_scan' | 'photo';
+
+export interface NunifRequest {
+  kind: 'swin_unet';
+  style: NunifStyle;
+  scale: 1 | 2 | 4;
+  noise: -1 | 0 | 1 | 2 | 3; // -1 = no noise reduction
+  tileSize: number;
+  width: number;
+  height: number;
+  pixels: ArrayBuffer; // RGBA8
+  baseUrl: string;
+}
+
+// Same response union as upscaler.worker.ts.
+export type NunifResponse =
+  | { kind: 'progress'; progress: number; info: string }
+  | { kind: 'error'; message: string }
+  | { kind: 'done'; pixels: ArrayBuffer; width: number; height: number };
+
+const BLEND_SIZE = 16;
+
+interface ArchConfig {
+  scale: number;
+  offset: number;
+  padding: 'replication' | 'reflection';
+  colorStability: boolean;
+  path: string;
+}
+
+const STYLE_PROPS: Record<NunifStyle, { colorStability: boolean; padding: 'replication' | 'reflection' }> = {
+  art: { colorStability: true, padding: 'replication' },
+  art_scan: { colorStability: false, padding: 'replication' },
+  photo: { colorStability: false, padding: 'reflection' },
+};
+
+/** Derive the upstream method name + offset from (scale, noise). */
+function resolveMethod(scale: number, noise: number): { method: string; offset: number } {
+  if (scale === 1) {
+    // scale 1 is denoise-only; noise must be specified.
+    return { method: `noise${noise}`, offset: 8 };
+  }
+  if (scale === 2) {
+    return { method: noise === -1 ? 'scale2x' : `noise${noise}_scale2x`, offset: 16 };
+  }
+  return { method: noise === -1 ? 'scale4x' : `noise${noise}_scale4x`, offset: 32 };
+}
+
+function getConfig(baseUrl: string, style: NunifStyle, scale: number, noise: number): ArchConfig {
+  const { method, offset } = resolveMethod(scale, noise);
+  const props = STYLE_PROPS[style];
+  return {
+    scale,
+    offset,
+    padding: props.padding,
+    colorStability: props.colorStability,
+    path: `${baseUrl}/models/swin_unet/${style}/${method}.onnx`,
+  };
+}
+
+function helperPath(baseUrl: string, name: string): string {
+  return `${baseUrl}/models/utils/${name}.onnx`;
+}
+
+/**
+ * swin_unet requires `(tile_size - 16)` divisible by both 12 and 16 (i.e. by 48).
+ * Round the requested size up to the next valid value.
+ */
+function calcTileSizeSwinUnet(tileSize: number): number {
+  let t = tileSize;
+  while (!((t - 16) % 12 === 0 && (t - 16) % 16 === 0)) t += 1;
+  return t;
+}
+
+// ── ONNX session cache ───────────────────────────────────────────────────────
+const sessions = new Map<string, ort.InferenceSession>();
+
+async function getSession(path: string): Promise<ort.InferenceSession> {
+  let s = sessions.get(path);
+  if (s) return s;
+  const resp = await fetch(path);
+  if (!resp.ok) throw new Error(`Failed to fetch model ${path}: ${resp.status} ${resp.statusText}`);
+  const buf = new Uint8Array(await resp.arrayBuffer());
+  s = await ort.InferenceSession.create(buf, { executionProviders: ['wasm'] });
+  sessions.set(path, s);
+  return s;
+}
+
+const scalarI64 = (v: number | bigint) => new ort.Tensor('int64', BigInt64Array.from([BigInt(v)]), []);
+
+// ── Tensor helpers (ported from nunif onnx_runner) ───────────────────────────
+
+/** RGBA8 (HWC, 0-255) -> CHW float32 (0-1), alpha blended over white. */
+function toInput(rgba: Uint8Array, width: number, height: number): ort.Tensor {
+  const rgb = new Float32Array(height * width * 3);
+  const bg = 1.0;
+  const hw = height * width;
+  for (let y = 0; y < height; ++y) {
+    for (let x = 0; x < width; ++x) {
+      const a = rgba[(y * width * 4) + (x * 4) + 3] / 255.0;
+      for (let c = 0; c < 3; ++c) {
+        const i = (y * width * 4) + (x * 4) + c;
+        const j = (y * width + x) + c * hw;
+        rgb[j] = a * (rgba[i] / 255.0) + (1 - a) * bg;
+      }
+    }
+  }
+  return new ort.Tensor('float32', rgb, [1, 3, height, width]);
+}
+
+/** CHW float32 (0-1) tile -> RGBA8 (HWC). */
+function toRgba(z: Float32Array, width: number, height: number): Uint8ClampedArray {
+  const rgba = new Uint8ClampedArray(height * width * 4);
+  const hw = height * width;
+  for (let y = 0; y < height; ++y) {
+    for (let x = 0; x < width; ++x) {
+      for (let c = 0; c < 3; ++c) {
+        const i = (y * width * 4) + (x * 4) + c;
+        const j = (y * width + x) + c * hw;
+        rgba[i] = (z[j] * 255.0) + 0.49999;
+      }
+      rgba[(y * width * 4) + (x * 4) + 3] = 255;
+    }
+  }
+  return rgba;
+}
+
+/** Crop an [B,C,H,W] tensor to a [B,C,height,width] window at (x,y). */
+function cropTensor(t: ort.Tensor, x: number, y: number, width: number, height: number): ort.Tensor {
+  const [B, C, H, W] = t.dims as number[];
+  const data = t.data as Float32Array;
+  const roi = new Float32Array(B * C * height * width);
+  let i = 0;
+  for (let b = 0; b < B; ++b) {
+    const bi = b * C * H * W;
+    for (let c = 0; c < C; ++c) {
+      const ci = bi + c * H * W;
+      for (let h = y; h < y + height; ++h) {
+        const hi = ci + h * W;
+        for (let w = x; w < x + width; ++w) roi[i++] = data[hi + w];
+      }
+    }
+  }
+  return new ort.Tensor('float32', roi, [B, C, height, width]);
+}
+
+/** If the whole tile is one colour, skip inference (returns [r,g,b] in 0-1). */
+function checkSingleColor(t: ort.Tensor): [number, number, number] | null {
+  const [B, C, H, W] = t.dims as number[];
+  const d = t.data as Float32Array;
+  const hw = H * W;
+  const r = d[0], g = d[hw], b = d[2 * hw];
+  for (let bi = 0; bi < B; ++bi) {
+    for (let h = 0; h < H; ++h) {
+      for (let w = 0; w < W; ++w) {
+        const i = bi * (C * hw) + h * W + w;
+        if (d[i] !== r || d[i + hw] !== g || d[i + 2 * hw] !== b) return null;
+      }
+    }
+  }
+  return [r, g, b];
+}
+
+function singleColorTensor([r, g, b]: [number, number, number], size: number): ort.Tensor {
+  const rgb = new Float32Array(size * size * 3);
+  const channel = [r, g, b];
+  for (let c = 0; c < 3; ++c) {
+    const v = channel[c];
+    for (let i = 0; i < size * size; ++i) rgb[c * size * size + i] = v;
+  }
+  return new ort.Tensor('float32', rgb, [1, 3, size, size]);
+}
+
+async function padding(
+  baseUrl: string, x: ort.Tensor,
+  left: number, right: number, top: number, bottom: number,
+  mode: 'replication' | 'reflection',
+): Promise<ort.Tensor> {
+  const ses = await getSession(helperPath(baseUrl, `${mode}_pad`));
+  const out = await ses.run({
+    x,
+    left: scalarI64(left), right: scalarI64(right),
+    top: scalarI64(top), bottom: scalarI64(bottom),
+  });
+  return out.y as ort.Tensor;
+}
+
+// ── Seam blending (ported from nunif/utils/seam_blending.py) ──────────────────
+interface SeamParams {
+  y_h: number; y_w: number;
+  input_offset: number; input_blend_size: number;
+  input_tile_step: number; output_tile_step: number;
+  h_blocks: number; w_blocks: number;
+  y_buffer_h: number; y_buffer_w: number;
+  pad: [number, number, number, number];
+}
+
+class SeamBlending {
+  param!: SeamParams;
+  pixels!: Float32Array;
+  weights!: Float32Array;
+  blendFilter!: ort.Tensor;
+  output!: Float32Array;
+
+  private xDims: readonly number[];
+  private scale: number;
+  private offset: number;
+  private tileSize: number;
+  private baseUrl: string;
+  private blendSize: number;
+
+  constructor(
+    xDims: readonly number[],
+    scale: number,
+    offset: number,
+    tileSize: number,
+    baseUrl: string,
+    blendSize = BLEND_SIZE,
+  ) {
+    this.xDims = xDims;
+    this.scale = scale;
+    this.offset = offset;
+    this.tileSize = tileSize;
+    this.baseUrl = baseUrl;
+    this.blendSize = blendSize;
+  }
+
+  async build() {
+    this.param = SeamBlending.calcParameters(this.xDims, this.scale, this.offset, this.tileSize, this.blendSize);
+    this.pixels = new Float32Array(this.param.y_buffer_h * this.param.y_buffer_w * 3);
+    this.weights = new Float32Array(this.param.y_buffer_h * this.param.y_buffer_w * 3);
+    this.blendFilter = await this.createBlendFilter();
+    this.output = new Float32Array(this.blendFilter.data.length);
+  }
+
+  update(x: ort.Tensor, tileI: number, tileJ: number): { data: Float32Array; w: number; h: number } {
+    const step = this.param.output_tile_step;
+    const [, H, W] = this.blendFilter.dims as number[];
+    const HW = H * W;
+    const bufW = this.param.y_buffer_w;
+    const bufHW = this.param.y_buffer_h * this.param.y_buffer_w;
+    const hI = step * tileI;
+    const wI = step * tileJ;
+    const filt = this.blendFilter.data as Float32Array;
+    const xd = x.data as Float32Array;
+
+    for (let c = 0; c < 3; ++c) {
+      for (let i = 0; i < H; ++i) {
+        for (let j = 0; j < W; ++j) {
+          const ti = c * HW + i * W + j;
+          const bi = c * bufHW + (hI + i) * bufW + (wI + j);
+          const oldW = this.weights[bi];
+          const nextW = oldW + filt[ti];
+          const ow = oldW / nextW;
+          this.pixels[bi] = this.pixels[bi] * ow + xd[ti] * (1.0 - ow);
+          this.weights[bi] = nextW;
+          this.output[ti] = this.pixels[bi];
+        }
+      }
+    }
+    return { data: this.output, w: W, h: H };
+  }
+
+  static calcParameters(xDims: readonly number[], scale: number, offset: number, tileSize: number, blendSize: number): SeamParams {
+    const x_h = xDims[2];
+    const x_w = xDims[3];
+    const input_offset = Math.ceil(offset / scale);
+    const input_blend_size = Math.ceil(blendSize / scale);
+    const input_tile_step = tileSize - (input_offset * 2 + input_blend_size);
+    const output_tile_step = input_tile_step * scale;
+
+    let h_blocks = 0, w_blocks = 0, input_h = 0, input_w = 0;
+    while (input_h < x_h + input_offset * 2) { input_h = h_blocks * input_tile_step + tileSize; ++h_blocks; }
+    while (input_w < x_w + input_offset * 2) { input_w = w_blocks * input_tile_step + tileSize; ++w_blocks; }
+
+    return {
+      y_h: x_h * scale, y_w: x_w * scale,
+      input_offset, input_blend_size, input_tile_step, output_tile_step,
+      h_blocks, w_blocks,
+      y_buffer_h: input_h * scale, y_buffer_w: input_w * scale,
+      pad: [input_offset, input_w - (x_w + input_offset), input_offset, input_h - (x_h + input_offset)],
+    };
+  }
+
+  private async createBlendFilter(): Promise<ort.Tensor> {
+    const ses = await getSession(helperPath(this.baseUrl, 'create_seam_blending_filter'));
+    const out = await ses.run({
+      scale: scalarI64(this.scale),
+      offset: scalarI64(this.offset),
+      tile_size: scalarI64(this.tileSize),
+    });
+    return out.y as ort.Tensor;
+  }
+}
+
+// ── Tiled render ─────────────────────────────────────────────────────────────
+async function tiledRender(
+  req: NunifRequest,
+  config: ArchConfig,
+  tileSize: number,
+  onProgress: (p: number) => void,
+): Promise<{ pixels: Uint8ClampedArray; width: number; height: number }> {
+  const model = await getSession(config.path);
+
+  let x = toInput(new Uint8Array(req.pixels), req.width, req.height);
+  const seam = new SeamBlending(x.dims, config.scale, config.offset, tileSize, req.baseUrl);
+  await seam.build();
+  const p = seam.param;
+  x = await padding(req.baseUrl, x, p.pad[0], p.pad[1], p.pad[2], p.pad[3], config.padding);
+
+  const outW = req.width * config.scale;
+  const outH = req.height * config.scale;
+  const out = new Uint8ClampedArray(outW * outH * 4);
+  out.fill(255);
+
+  const tiles: Array<[number, number, number, number, number, number]> = [];
+  for (let hI = 0; hI < p.h_blocks; ++hI) {
+    for (let wI = 0; wI < p.w_blocks; ++wI) {
+      tiles.push([
+        hI * p.input_tile_step, wI * p.input_tile_step,
+        hI * p.output_tile_step, wI * p.output_tile_step,
+        hI, wI,
+      ]);
+    }
+  }
+
+  const total = tiles.length;
+  for (let k = 0; k < total; ++k) {
+    const [i, j, ii, jj, hI, wI] = tiles[k];
+    const tileX = cropTensor(x, j, i, tileSize, tileSize);
+
+    let tileY: ort.Tensor;
+    const single = config.colorStability ? checkSingleColor(tileX) : null;
+    if (single == null) {
+      const res = await model.run({ x: tileX });
+      tileY = res.y as ort.Tensor;
+    } else {
+      tileY = singleColorTensor(single, tileSize * config.scale - config.offset * 2);
+    }
+
+    const blended = seam.update(tileY, hI, wI);
+    const tileRgba = toRgba(blended.data, blended.w, blended.h);
+    blitTile(out, outW, outH, tileRgba, blended.w, blended.h, jj, ii);
+
+    onProgress(((k + 1) / total) * 100);
+  }
+
+  return { pixels: out, width: outW, height: outH };
+}
+
+function blitTile(
+  out: Uint8ClampedArray, outW: number, outH: number,
+  tile: Uint8ClampedArray, tw: number, th: number, dx: number, dy: number,
+) {
+  for (let y = 0; y < th; ++y) {
+    const oy = dy + y;
+    if (oy < 0 || oy >= outH) continue;
+    for (let x = 0; x < tw; ++x) {
+      const ox = dx + x;
+      if (ox < 0 || ox >= outW) continue;
+      const si = (y * tw + x) * 4;
+      const di = (oy * outW + ox) * 4;
+      out[di] = tile[si];
+      out[di + 1] = tile[si + 1];
+      out[di + 2] = tile[si + 2];
+      out[di + 3] = 255;
+    }
+  }
+}
+
+self.addEventListener('message', async (e: MessageEvent<NunifRequest>) => {
+  const req = e.data;
+  const post = (msg: NunifResponse, transfer?: Transferable[]) =>
+    transfer ? self.postMessage(msg, transfer) : self.postMessage(msg);
+
+  try {
+    if (req.scale === 1 && req.noise === -1) {
+      throw new Error('Scale 1× requires a noise-reduction level');
+    }
+    post({ kind: 'progress', progress: 0, info: 'Loading swin_unet model…' });
+
+    const config = getConfig(req.baseUrl, req.style, req.scale, req.noise);
+    const tileSize = calcTileSizeSwinUnet(req.tileSize);
+
+    const result = await tiledRender(req, config, tileSize, (progress) => {
+      post({ kind: 'progress', progress, info: `Upscaling ${progress.toFixed(0)}%` });
+    });
+
+    const buf = result.pixels.buffer as ArrayBuffer;
+    post({ kind: 'done', pixels: buf, width: result.width, height: result.height }, [buf]);
+  } catch (err) {
+    post({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
+  }
+});
+
+export {};


### PR DESCRIPTION
## What

Ports the super-resolution logic from the nunif / waifu2x web app (https://test.1ink.us/nunif/) into Chromashift, **alongside** the existing TensorFlow.js Real-ESRGAN / Real-CUGAN path (non-destructive).

## How

New `src/engine/nunif.worker.ts` runs the original waifu2x `swin_unet` ONNX models via **onnxruntime-web** (faithful port of nunif's `onnx_runner`):

- **Cumulative seam/border blending** (`SeamBlending`, ported from `nunif/utils/seam_blending.py`) for seamless tiling.
- **Replication / reflection padding** via the upstream helper ONNX models.
- **Single-color tile fast-path** (color stability) skipping inference on flat tiles.
- swin_unet tile-size constraint handling (`(tile-16) % 12 == 0 && % 16 == 0`).

Scope per discussion: **RGB only** — no alpha-channel handling and no TTA (the helper models for those are not wired up yet).

### UI

The upscale panel gains a `waifu2x swin_unet (ONNX)` engine group with selectors for:
- **Style**: art / art_scan / photo
- **Scale**: 1× (denoise-only) / 2× / 4×
- **Noise reduction**: none / 0–3

All encoded into the existing `upscaleModel` string, so no new props were threaded through.

### Models

Reused from the nunif host (`https://test.1ink.us/nunif/models/...`), which serves them with `Access-Control-Allow-Origin: *` (verified). Override with `VITE_NUNIF_BASE` to self-host. onnxruntime-web wasm binaries load from the matching jsdelivr CDN build.

## Verification

- `tsc -b` ✓ · `eslint` ✓ · `vite build` ✓
- All four required model/helper URLs return HTTP 200 with CORS enabled.

Not yet runtime-tested in a browser against a live image — worth a manual smoke test before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhxacG9JcVZDt9B5aAuqrR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Swin-UNet upscaling model support with configurable style, output scale (1×, 2×, 4×), and noise reduction parameters.
  * Enhanced upscale UI with dynamic model selector and dedicated controls for scale and noise adjustment when using Swin-UNet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->