### PR TITLE
Add optional Sobel edge boost and soft CROP band toggles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,6 +94,8 @@ export default function App() {
   const [layerScale, setLayerScale] = useState(1.0);
   const [tracerScale, setTracerScale] = useState(1.0);
   const [colorMode, setColorMode] = useState(1); // 1 = Vivid Gradient, 0 = Fixed cr0p
+  const [sobelEnabled, setSobelEnabled] = useState(false);
+  const [softCropEnabled, setSoftCropEnabled] = useState(false);
   const [specificImageError, setSpecificImageError] = useState<string | null>(null);
   const [renderCpuTiming, setRenderCpuTiming] = useState({ last: 0, avg: 0 });
   const [collisionStats, setCollisionStats] = useState({
@@ -539,6 +541,8 @@ export default function App() {
           tracerBelowDuration: tracerBelowDuration * (60 / frameRate),
           tracerMode,
           colorMode,
+          sobelEnabled,
+          softCropEnabled,
           layerBlendMode,
           tracerBlendMode,
           outputMode,
@@ -621,7 +625,7 @@ export default function App() {
     return () => {
       if (animFrameRef.current !== null) cancelAnimationFrame(animFrameRef.current);
     };
-  }, [gpuReady, frameRate, layerExtensions, avgLuminance, layerOpacity, layerOpacities, layerScale, tracerScale, tracerAboveIntensity, tracerBelowIntensity, tracerAboveDuration, tracerBelowDuration, tracerMode, colorMode, layerBlendMode, tracerBlendMode, outputMode, tracerPreviewFrozen, livePreviewEnabled, isPaused, isViewingTracer, mainViewMode, tracerInspectZoom, tracerInspectPan, tracerInspectHeatmap, tracerInspectExposure, tracerInspectTonemap, tracerInspectShowLayers, diagnosticsMode, diagnosticsOpacity, stampBoost, peakCollisionsOnly]);
+  }, [gpuReady, frameRate, layerExtensions, avgLuminance, layerOpacity, layerOpacities, layerScale, tracerScale, tracerAboveIntensity, tracerBelowIntensity, tracerAboveDuration, tracerBelowDuration, tracerMode, colorMode, sobelEnabled, softCropEnabled, layerBlendMode, tracerBlendMode, outputMode, tracerPreviewFrozen, livePreviewEnabled, isPaused, isViewingTracer, mainViewMode, tracerInspectZoom, tracerInspectPan, tracerInspectHeatmap, tracerInspectExposure, tracerInspectTonemap, tracerInspectShowLayers, diagnosticsMode, diagnosticsOpacity, stampBoost, peakCollisionsOnly]);
 
   useEffect(() => {
     const canvas = previewTracerRef.current;
@@ -1401,6 +1405,10 @@ export default function App() {
         onPeakCollisionsOnlyChange={setPeakCollisionsOnly}
         colorMode={colorMode}
         onColorModeChange={setColorMode}
+        sobelEnabled={sobelEnabled}
+        onSobelEnabledToggle={setSobelEnabled}
+        softCropEnabled={softCropEnabled}
+        onSoftCropEnabledToggle={setSoftCropEnabled}
         onSquareCanvasToggle={setSquareCanvas}
         onAntialiasToggle={(enabled) => {
           setAntialiasEnabled(enabled);

--- a/src/components/NunifOverlay.tsx
+++ b/src/components/NunifOverlay.tsx
@@ -62,6 +62,10 @@ interface Props {
   onResetInspectView         : () => void;
   onExportTracer             : () => void;
   colorMode                  : number;
+  sobelEnabled               : boolean;
+  onSobelEnabledToggle       : (v: boolean) => void;
+  softCropEnabled            : boolean;
+  onSoftCropEnabledToggle    : (v: boolean) => void;
   squareCanvas               : boolean;
   antialiasEnabled           : boolean;
   onAngleChange              : (layer: 0 | 1 | 2, angle: number) => void;
@@ -162,6 +166,10 @@ export function NunifOverlay({
   onResetInspectView,
   onExportTracer,
   colorMode,
+  sobelEnabled,
+  onSobelEnabledToggle,
+  softCropEnabled,
+  onSoftCropEnabledToggle,
   squareCanvas,
   antialiasEnabled,
   onAngleChange,
@@ -545,6 +553,36 @@ export function NunifOverlay({
                   {label}
                 </button>
               ))}
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <span className="text-xs text-amber-400/80 font-mono">Band shaping:</span>
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={() => onSobelEnabledToggle(!sobelEnabled)}
+                className={`flex-1 text-[10px] px-1 py-1 rounded transition-all ${
+                  sobelEnabled
+                    ? 'bg-emerald-600 text-white shadow-[0_0_8px_rgba(16,185,129,0.4)]'
+                    : 'bg-zinc-800 border border-amber-500/30 hover:bg-zinc-700'
+                }`}
+                title="Sobel edge boost on luminance before band assignment. Off = raw luminance (CROP reference parity)."
+              >
+                {sobelEnabled ? '◎ Sobel ON' : '○ Sobel'}
+              </button>
+              <button
+                type="button"
+                onClick={() => onSoftCropEnabledToggle(!softCropEnabled)}
+                className={`flex-1 text-[10px] px-1 py-1 rounded transition-all ${
+                  softCropEnabled
+                    ? 'bg-sky-600 text-white shadow-[0_0_8px_rgba(56,189,248,0.4)]'
+                    : 'bg-zinc-800 border border-amber-500/30 hover:bg-zinc-700'
+                }`}
+                title="Soft band edges in CROP / N2 modes. Off = hard thresholds matching the go.1ink.us CROP reference."
+              >
+                {softCropEnabled ? '≈ Soft ON' : '≈ Soft'}
+              </button>
             </div>
           </div>
 

--- a/src/engine/WebGPURenderer.ts
+++ b/src/engine/WebGPURenderer.ts
@@ -45,6 +45,8 @@ export interface RendererState {
   tracerThreshold?     : number;
   tracerMode?          : number;  // 0 = combined colors, 1 = grey highlight
   colorMode?           : number;  // 0 = Fixed (cr0p), 1 = Vivid (Chromashift gradient), 2 = CROP, 3 = CROP NUNIF2
+  sobelEnabled?        : boolean; // Sobel edge boost on luminance before band assignment
+  softCropEnabled?     : boolean; // Soft band edges in CROP / NUNIF2 (hard cuts when false)
   layerBlendMode?      : number;  // 0=alpha, 1=add, 2=subtract, 3=multiply, 4=screen, 5=lighten, 6=darken, 7=overlay, 8=color dodge, 9=color burn, 10=difference, 11=exclusion, 12=hard light
   tracerBlendMode?     : number;  // 0=alpha, 1=add, 2=subtract, 3=multiply, 4=screen, 5=lighten, 6=darken, 7=overlay, 8=color dodge, 9=color burn, 10=difference, 11=exclusion, 12=hard light
   outputMode?          : number;  // 0 = mixed, 1 = tracer focus, 2 = tracer only
@@ -475,10 +477,10 @@ export class WebGPURenderer {
       size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
     const fragUniformBuffer = device.createBuffer({
-      size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+      size: 32, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
-    return { pipeline, bindGroupLayout, rotationBuffer, fragUniformBuffer, rotationData: new Float32Array(4), fragData: new Float32Array(4) };
+    return { pipeline, bindGroupLayout, rotationBuffer, fragUniformBuffer, rotationData: new Float32Array(4), fragData: new Float32Array(8) };
   }
 
   // ─── Persistence pipeline ────────────────────────────────────────────────────
@@ -1244,8 +1246,13 @@ export class WebGPURenderer {
 
       const colorMode = state.colorMode ?? 1.0;
       const useMask = this.classificationMaskTexture && colorMode === 0 ? 1 : 0;
-      lp.fragData.set([state.avgLuminance, layerOpacities[i], colorMode, useMask]);
-      this.device.queue.writeBuffer(lp.fragUniformBuffer, 0, lp.fragData.buffer as ArrayBuffer, lp.fragData.byteOffset, 16);
+      const sobelEnabled = state.sobelEnabled ? 1 : 0;
+      const softCropEnabled = state.softCropEnabled ? 1 : 0;
+      lp.fragData.set([
+        state.avgLuminance, layerOpacities[i], colorMode, useMask,
+        sobelEnabled, softCropEnabled, 0, 0,
+      ]);
+      this.device.queue.writeBuffer(lp.fragUniformBuffer, 0, lp.fragData.buffer as ArrayBuffer, lp.fragData.byteOffset, 32);
 
       const bindGroup = this.getLayerBindGroup(i);
 

--- a/src/engine/shaders.ts
+++ b/src/engine/shaders.ts
@@ -90,6 +90,113 @@ fn band_gradient(
 fn softThreshold(v: f32, edge: f32, width: f32) -> f32 {
   return smoothstep(edge - width, edge + width, v);
 }
+
+const SOFT_CROP_TW : f32 = 2.2;
+const SOBEL_EDGE_BOOST : f32 = 16.0;
+
+fn pixelLuminanceAt(tex: texture_2d<f32>, texSampler: sampler, uv: vec2<f32>) -> f32 {
+  let sample = textureSample(tex, texSampler, uv);
+  return dot(sample.rgb, vec3<f32>(0.2126, 0.7152, 0.0722)) * 255.0;
+}
+
+// Sobel gradient magnitude on BT.709 luminance — boosts edge pixels before band assignment.
+fn sobelBoostedLuminance(
+  tex: texture_2d<f32>,
+  texSampler: sampler,
+  uv: vec2<f32>,
+  baseLum: f32,
+  enabled: f32,
+) -> f32 {
+  if (enabled < 0.5) { return baseLum; }
+  let dims = vec2<f32>(textureDimensions(tex));
+  let px = vec2<f32>(1.0 / dims.x, 1.0 / dims.y);
+  let tl = pixelLuminanceAt(tex, texSampler, uv + vec2<f32>(-px.x, -px.y));
+  let tc = pixelLuminanceAt(tex, texSampler, uv + vec2<f32>(0.0, -px.y));
+  let tr = pixelLuminanceAt(tex, texSampler, uv + vec2<f32>(px.x, -px.y));
+  let ml = pixelLuminanceAt(tex, texSampler, uv + vec2<f32>(-px.x, 0.0));
+  let mr = pixelLuminanceAt(tex, texSampler, uv + vec2<f32>(px.x, 0.0));
+  let bl = pixelLuminanceAt(tex, texSampler, uv + vec2<f32>(-px.x, px.y));
+  let bc = pixelLuminanceAt(tex, texSampler, uv + vec2<f32>(0.0, px.y));
+  let br = pixelLuminanceAt(tex, texSampler, uv + vec2<f32>(px.x, px.y));
+  let gx = -tl - 2.0 * ml - bl + tr + 2.0 * mr + br;
+  let gy = -tl - 2.0 * tc - tr + bl + 2.0 * bc + br;
+  let mag = length(vec2<f32>(gx, gy));
+  return clamp(baseLum + SOBEL_EDGE_BOOST * mag, 0.0, 255.0);
+}
+
+fn cropLayer0Color(bandLum: f32, soft: f32, nonAlpha: f32, darkAlpha: f32) -> vec4<f32> {
+  let grey = vec4<f32>(0.753, 0.753, 0.753, nonAlpha);
+  let orange = vec4<f32>(1.0, 0.627, 0.0, nonAlpha);
+  let red = vec4<f32>(1.0, 0.0, 0.0, nonAlpha);
+  let dark = vec4<f32>(0.0, 0.0, 0.0, darkAlpha);
+  if (soft < 0.5) {
+    if (bandLum >= 229.0) { return grey; }
+    if (bandLum >= 209.0) { return orange; }
+    if (bandLum >= 190.0) { return red; }
+    return dark;
+  }
+  let tw = SOFT_CROP_TW;
+  if (bandLum >= 229.0 - tw) {
+    return mix(orange, grey, softThreshold(bandLum, 229.0, tw));
+  }
+  if (bandLum >= 209.0 - tw) {
+    return mix(red, orange, softThreshold(bandLum, 209.0, tw));
+  }
+  if (bandLum >= 190.0 - tw) {
+    return mix(dark, red, softThreshold(bandLum, 190.0, tw));
+  }
+  return dark;
+}
+
+fn cropLayer1Color(bandLum: f32, soft: f32, nonAlpha: f32, darkAlpha: f32) -> vec4<f32> {
+  let violet = vec4<f32>(0.502, 0.0, 0.502, nonAlpha);
+  let blue = vec4<f32>(0.0, 0.0, 0.545, nonAlpha);
+  let borderBlue = vec4<f32>(0.0, 0.0, 1.0, nonAlpha);
+  let dark = vec4<f32>(0.0, 0.0, 0.0, darkAlpha);
+  if (soft < 0.5) {
+    if (bandLum >= 177.0 && bandLum < 190.0) { return violet; }
+    if (bandLum >= 161.0 && bandLum < 177.0) { return blue; }
+    if (bandLum >= 158.0 && bandLum < 161.0) { return borderBlue; }
+    return dark;
+  }
+  let tw = SOFT_CROP_TW;
+  if (bandLum >= 177.0 - tw) {
+    let inner = mix(blue, violet, softThreshold(bandLum, 177.0, tw));
+    return mix(inner, dark, softThreshold(bandLum, 190.0, tw));
+  }
+  if (bandLum >= 161.0 - tw) {
+    return mix(borderBlue, blue, softThreshold(bandLum, 177.0, tw));
+  }
+  if (bandLum >= 158.0 - tw) {
+    return mix(dark, borderBlue, softThreshold(bandLum, 161.0, tw));
+  }
+  return dark;
+}
+
+fn cropLayer2Color(bandLum: f32, soft: f32, nonAlpha: f32, darkAlpha: f32) -> vec4<f32> {
+  let green = vec4<f32>(0.0, 0.502, 0.0, nonAlpha);
+  let yellow = vec4<f32>(0.502, 1.0, 0.0, nonAlpha);
+  let borderYellow = vec4<f32>(1.0, 1.0, 0.0, nonAlpha);
+  let dark = vec4<f32>(0.0, 0.0, 0.0, darkAlpha);
+  if (soft < 0.5) {
+    if (bandLum >= 145.0 && bandLum < 158.0) { return green; }
+    if (bandLum >= 128.0 && bandLum < 145.0) { return yellow; }
+    if (bandLum >= 125.0 && bandLum < 128.0) { return borderYellow; }
+    return dark;
+  }
+  let tw = SOFT_CROP_TW;
+  if (bandLum >= 145.0 - tw) {
+    let inner = mix(yellow, green, softThreshold(bandLum, 145.0, tw));
+    return mix(inner, dark, softThreshold(bandLum, 158.0, tw));
+  }
+  if (bandLum >= 128.0 - tw) {
+    return mix(borderYellow, yellow, softThreshold(bandLum, 145.0, tw));
+  }
+  if (bandLum >= 125.0 - tw) {
+    return mix(dark, borderYellow, softThreshold(bandLum, 128.0, tw));
+  }
+  return dark;
+}
 `;
 
 // ─── Fragment: Layer 0 – Red / Orange ──────────────────────────────────────────────
@@ -100,17 +207,22 @@ ${WGSL_COLOR_HELPERS}
 @group(0) @binding(4) var classMask  : texture_2d<u32>;
 
 struct FragUniforms {
-  avgLuminance : f32,
-  layerOpacity : f32,
-  colorMode    : f32,
-  useMask      : f32,
+  avgLuminance     : f32,
+  layerOpacity     : f32,
+  colorMode        : f32,
+  useMask          : f32,
+  sobelEnabled     : f32,
+  softCropEnabled  : f32,
+  _pad0            : f32,
+  _pad1            : f32,
 };
 @group(0) @binding(3) var<uniform> fragUniforms : FragUniforms;
 
 @fragment
 fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
   let sample = textureSample(tex, texSampler, uv);
-  let lum    = dot(sample.rgb, vec3<f32>(0.2126, 0.7152, 0.0722)) * 255.0;
+  let rawLum = dot(sample.rgb, vec3<f32>(0.2126, 0.7152, 0.0722)) * 255.0;
+  let lum    = sobelBoostedLuminance(tex, texSampler, uv, rawLum, fragUniforms.sobelEnabled);
   let dims   = vec2<f32>(textureDimensions(classMask));
   let maskUv = clamp(uv, vec2<f32>(0.0), vec2<f32>(0.99999994));
   let maskPx = vec2<i32>(maskUv * dims);
@@ -133,15 +245,7 @@ fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
     let bandLum   = select(lum, adj, isNunif2);
     let nonAlpha  = select(1.0, 0.5, isNunif2);   // NUNIF2 Layer 1 opacity = 0.5
     let darkAlpha = select(0.0, 0.1, isNunif2);
-    if (bandLum >= 229.0) {
-      result = vec4<f32>(0.753, 0.753, 0.753, nonAlpha);
-    } else if (bandLum >= 209.0) {
-      result = vec4<f32>(1.0, 0.627, 0.0, nonAlpha);
-    } else if (bandLum >= 190.0) {
-      result = vec4<f32>(1.0, 0.0, 0.0, nonAlpha);
-    } else {
-      result = vec4<f32>(0.0, 0.0, 0.0, darkAlpha);
-    }
+    result = cropLayer0Color(bandLum, fragUniforms.softCropEnabled, nonAlpha, darkAlpha);
   } else {
     // --- ORIGINAL CR0P FIXED ---
     let diff      = (fragUniforms.avgLuminance / 255.0) * 32.0;
@@ -202,17 +306,22 @@ ${WGSL_COLOR_HELPERS}
 @group(0) @binding(4) var classMask  : texture_2d<u32>;
 
 struct FragUniforms {
-  avgLuminance : f32,
-  layerOpacity : f32,
-  colorMode    : f32,
-  useMask      : f32,
+  avgLuminance     : f32,
+  layerOpacity     : f32,
+  colorMode        : f32,
+  useMask          : f32,
+  sobelEnabled     : f32,
+  softCropEnabled  : f32,
+  _pad0            : f32,
+  _pad1            : f32,
 };
 @group(0) @binding(3) var<uniform> fragUniforms : FragUniforms;
 
 @fragment
 fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
   let sample = textureSample(tex, texSampler, uv);
-  let lum    = dot(sample.rgb, vec3<f32>(0.2126, 0.7152, 0.0722)) * 255.0;
+  let rawLum = dot(sample.rgb, vec3<f32>(0.2126, 0.7152, 0.0722)) * 255.0;
+  let lum    = sobelBoostedLuminance(tex, texSampler, uv, rawLum, fragUniforms.sobelEnabled);
   let dims   = vec2<f32>(textureDimensions(classMask));
   let maskUv = clamp(uv, vec2<f32>(0.0), vec2<f32>(0.99999994));
   let maskPx = vec2<i32>(maskUv * dims);
@@ -233,15 +342,7 @@ fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
     let bandLum   = select(lum, adj, isNunif2);
     let nonAlpha  = select(1.0, 0.777, isNunif2);  // NUNIF2 Layer 2 opacity = 0.777
     let darkAlpha = select(0.0, 0.1, isNunif2);
-    if (bandLum >= 177.0 && bandLum < 190.0) {
-      result = vec4<f32>(0.502, 0.0, 0.502, nonAlpha);
-    } else if (bandLum >= 161.0 && bandLum < 177.0) {
-      result = vec4<f32>(0.0, 0.0, 0.545, nonAlpha);
-    } else if (bandLum >= 158.0 && bandLum < 161.0) {
-      result = vec4<f32>(0.0, 0.0, 1.0, nonAlpha);
-    } else {
-      result = vec4<f32>(0.0, 0.0, 0.0, darkAlpha);
-    }
+    result = cropLayer1Color(bandLum, fragUniforms.softCropEnabled, nonAlpha, darkAlpha);
   } else {
     // --- ORIGINAL CR0P FIXED ---
     let diff      = (fragUniforms.avgLuminance / 255.0) * 32.0;
@@ -289,17 +390,22 @@ ${WGSL_COLOR_HELPERS}
 @group(0) @binding(4) var classMask  : texture_2d<u32>;
 
 struct FragUniforms {
-  avgLuminance : f32,
-  layerOpacity : f32,
-  colorMode    : f32,
-  useMask      : f32,
+  avgLuminance     : f32,
+  layerOpacity     : f32,
+  colorMode        : f32,
+  useMask          : f32,
+  sobelEnabled     : f32,
+  softCropEnabled  : f32,
+  _pad0            : f32,
+  _pad1            : f32,
 };
 @group(0) @binding(3) var<uniform> fragUniforms : FragUniforms;
 
 @fragment
 fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
   let sample = textureSample(tex, texSampler, uv);
-  let lum    = dot(sample.rgb, vec3<f32>(0.2126, 0.7152, 0.0722)) * 255.0;
+  let rawLum = dot(sample.rgb, vec3<f32>(0.2126, 0.7152, 0.0722)) * 255.0;
+  let lum    = sobelBoostedLuminance(tex, texSampler, uv, rawLum, fragUniforms.sobelEnabled);
   let dims   = vec2<f32>(textureDimensions(classMask));
   let maskUv = clamp(uv, vec2<f32>(0.0), vec2<f32>(0.99999994));
   let maskPx = vec2<i32>(maskUv * dims);
@@ -320,15 +426,7 @@ fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
     let bandLum   = select(lum, adj, isNunif2);
     let nonAlpha  = select(1.0, 0.777, isNunif2);  // NUNIF2 Layer 3 opacity = 0.777
     let darkAlpha = select(0.0, 0.1, isNunif2);
-    if (bandLum >= 145.0 && bandLum < 158.0) {
-      result = vec4<f32>(0.0, 0.502, 0.0, nonAlpha);
-    } else if (bandLum >= 128.0 && bandLum < 145.0) {
-      result = vec4<f32>(0.502, 1.0, 0.0, nonAlpha);
-    } else if (bandLum >= 125.0 && bandLum < 128.0) {
-      result = vec4<f32>(1.0, 1.0, 0.0, nonAlpha);
-    } else {
-      result = vec4<f32>(0.0, 0.0, 0.0, darkAlpha);
-    }
+    result = cropLayer2Color(bandLum, fragUniforms.softCropEnabled, nonAlpha, darkAlpha);
   } else {
     // --- ORIGINAL CR0P FIXED ---
     let diff      = (fragUniforms.avgLuminance / 255.0) * 32.0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds two opt-in band-shaping controls for color separation, both **off by default** so CROP mode (🌿) keeps hard-threshold reference parity with go.1ink.us when disabled.

- **Sobel** — 3×3 Sobel gradient boost on BT.709 luminance before band assignment (all spectrum modes). Emphasizes geometric edges in crop damage patterns.
- **Soft** — 2.2-unit `smoothstep` ramps at CROP / N2 band boundaries instead of hard cuts.

## UI

New **Band shaping** row under Spectrum in the NUNIF panel:
- `○ Sobel` / `◎ Sobel ON` toggle
- `≈ Soft` / `≈ Soft ON` toggle (CROP / N2 only)

## Implementation

- WGSL helpers: `sobelBoostedLuminance`, `cropLayer0/1/2Color` in `shaders.ts`
- Extended layer fragment uniform buffer (16 → 32 bytes) with `sobelEnabled` and `softCropEnabled` flags
- State wired through `App.tsx` → `WebGPURenderer` → layer shaders

## Notes

- Sobel uses a fixed boost of 16 luminance units at full edge magnitude.
- Fixed (🧱) mode already had soft thresholds; the Soft toggle only affects CROP / N2.
- Vivid (🌈) mode receives Sobel when enabled but is unchanged by the Soft toggle.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5294763-6e4c-45e2-be1b-41c2af91377d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5294763-6e4c-45e2-be1b-41c2af91377d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Band shaping" controls to the rendering overlay with two new toggles:
    * Sobel edge boosting for enhanced edge detection in luminance processing
    * Soft band edges for smoother transitions between color bands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->